### PR TITLE
Change destination path for log.properties in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ COPY files/plugins.txt /usr/share/jenkins/ref/plugins.txt
 COPY files/executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
 
 # enable logging
-COPY files/log.properties /var/jenkins_home/log.properties
+COPY files/log.properties /usr/share/jenkins/ref/log.properties
 
 # disable security
 #COPY config.xml  /usr/share/jenkins/ref/config.xml


### PR DESCRIPTION
For consistency, I change the destination path to `/usr/share/jenkins/ref/`
as we copy all the configuration files to there.

I have tested this and the logs are still flowing.

The [/usr/local/bin/jenkins.sh](https://github.com/jenkinsci/docker/blob/master/jenkins.sh) script (which launches Jenkins) copies all the files
from `/usr/share/jenkins/ref/` to the Jenkins home folder before invoking `java`
with the option `-Djava.util.logging.config.file=/var/jenkins_home/log.properties"`,
so by then the `log.properties` should be already in its final location.