### PR TITLE
Update version of vpc module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.10.0"
+  version = "~> 1.11.0"
   region  = "${var.aws_region}"
 
   # shared_credentials_file = "~/.aws/credentials"

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,6 +1,6 @@
 module "jenkins2_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "1.9.1"
+  version = "1.30.0"
 
   name = "jenkins_vpc_${var.product}-${var.environment}"
 


### PR DESCRIPTION
Update version of terraform-aws-modules/vpc/aws to current version. Terraform tested and Jenkins starts up no probs

Solo: @poveyd