### PR TITLE
[DO NOT MERGE] Allow Docker containers to be spawned by the Jenkins container

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ You need `docker` >= `v18.03.0`
 ```
 cd docker
 docker build -t="jenkins/jenkins-re" .
-docker run --name myjenkins -ti -p 8000:80 -p 50000:50000 jenkins/jenkins-re:latest
+docker run --name myjenkins -v /var/run/docker.sock:/var/run/docker.sock -ti -p 8000:80 -p 50000:50000 jenkins/jenkins-re:latest
 ```
+In the command above, the `-v` argument is optional, but needed if you want to start new docker containers on the host from within the Jenkins container (e.g. containers to run tests or build artifacts).
 
 To access the instance browse to [here](http://localhost:8000)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,17 @@ RUN apt-get install -y nginx
 COPY files/nginx-jenkins /etc/nginx/sites-enabled/jenkins
 RUN rm -rf /etc/nginx/sites-enabled/default
 
+# install docker
+ARG DOCKER_CLIENT=docker-17.06.2-ce.tgz
+
+RUN cd /tmp/ \
+&& curl -sSL -O https://download.docker.com/linux/static/stable/x86_64/${DOCKER_CLIENT} \
+&& tar zxf ${DOCKER_CLIENT} \
+&& mkdir -p /usr/local/bin \
+&& mv ./docker/docker /usr/local/bin \
+&& chmod +x /usr/local/bin/docker \
+&& rm -rf /tmp/*
+
 # drop back to jenkins user
 USER jenkins
 

--- a/docker/files/start-jenkins.sh
+++ b/docker/files/start-jenkins.sh
@@ -7,6 +7,9 @@ catchtrap() {
   exit 1
 }
 
+# to allow Jenkins to access the docker socket
+chmod 666 /var/run/docker.sock
+
 service nginx start
 su -m jenkins -c /usr/local/bin/jenkins.sh
 


### PR DESCRIPTION
**This is experimental.**
We are well aware of its security flow.

This allows the Jenkins container to spawn other Docker containers. E.g. in
the project you want to build, there is a Jenkinsfile that specifies a
Docker container to run the steps in.

This was achieved by:
 - installing Docker in the Jenkins container
 - "mounting" the host's /var/run/docker.sock when running the Jenkins container

I am not terribly happy about this chmod 666 /var/run/docker.sock - I would like to hear feedback from the reviewer.

At the moment, you can see an example of Jenkinsfile and Dockerfile here:
https://github.com/alphagov/re-build-systems-sample-java-app/blob/master/Jenkinsfile