### PR TITLE
Adding persistent storage

### DIFF
--- a/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
+++ b/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
@@ -9,6 +9,38 @@ random_seed:
   command: ['sh', '-c', '(ec2metadata && date +%s%3N) | sha256sum > /dev/urandom']
   command_required: True
 locale: en_GB.UTF-8
+write_files:
+  - content: |
+      #!/usr/bin/env bash
+      echo "Waiting until EBS attachment to instance complete"
+      while [ ! -e /dev/xvdf ]; do sleep 1; done
+      check_xvdf=$(lsblk /dev/xvdf -no KNAME,FSTYPE|tr -d '[:space:]'|tr a-z A-Z)
+      if [ ! x"$check_xvdf" == "xXVDFEXT4" ]; then
+        echo "New EBS volume detected, formating"
+        mkfs.ext4 -F -m 0 -O dir_index,sparse_super,uninit_bg -q /dev/xvdf
+      else
+        echo "/dev/xvdf Already formatted, skipping"
+      fi
+      fstab_string='/dev/xvdf /mnt/jenkins-ebs ext4 defaults,nofail,nobootwait 0 2'
+      grepresult=$(grep -x -F -c '/dev/xvdf /mnt/jenkins-ebs ext4 defaults,nofail,nobootwait 0 2' /etc/fstab)
+      if [ $grepresult -eq 0 ]; then
+        echo "Adding mountpoint to fstab"
+        echo "$fstab_string" | tee -a /etc/fstab
+      fi
+      if [ ! -d /mnt/jenkins-ebs ]; then
+        echo "Creating mountpoint /mnt/jenkins-ebs"
+        mkdir -p /mnt/jenkins-ebs
+        chown 1000:1000 /mnt/jenkins-ebs
+      fi
+      if [ ! $(mount | grep xvdf | wc -l) == "1" ]; then
+        echo "Mounting /dev/xvdf on /mnt/jenkins-ebs"
+        mount -t ext4 /dev/xvdf /mnt/jenkins-ebs
+        chown 1000:1000 /mnt/jenkins-ebs
+      else
+        echo "/dev/xvdf Already mounted, skipping"
+      fi
+    path: /usr/local/bin/mount-xvdf
+    permissions: '0555'
 apt_preserve_sources_list: true
 apt_sources:
  - source: "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
@@ -195,4 +227,5 @@ runcmd:
   - [ mkdir, /docker ]
   - git clone ${gitrepo} /docker
   - [ docker, build, -t=jenkins/jenkins-re, "/docker/docker" ]
+  - /usr/local/bin/mount-xvdf
   - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", "jenkins/jenkins-re:latest" ]

--- a/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
+++ b/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
@@ -17,6 +17,8 @@ write_files:
       check_xvdf=$(lsblk /dev/xvdf -no KNAME,FSTYPE|tr -d '[:space:]'|tr a-z A-Z)
       if [ ! x"$check_xvdf" == "xXVDFEXT4" ]; then
         echo "New EBS volume detected, formating"
+        # Note: We are formatting the raw device rather than a partition on the raw device
+        #       This allows for easier and simpler disk expansion in the future
         mkfs.ext4 -F -m 0 -O dir_index,sparse_super,uninit_bg -q /dev/xvdf
       else
         echo "/dev/xvdf Already formatted, skipping"
@@ -39,7 +41,7 @@ write_files:
       else
         echo "/dev/xvdf Already mounted, skipping"
       fi
-    path: /usr/local/bin/mount-xvdf
+    path: /usr/local/bin/mount-persistent-storage
     permissions: '0555'
 apt_preserve_sources_list: true
 apt_sources:
@@ -227,5 +229,5 @@ runcmd:
   - [ mkdir, /docker ]
   - git clone ${gitrepo} /docker
   - [ docker, build, -t=jenkins/jenkins-re, "/docker/docker" ]
-  - /usr/local/bin/mount-xvdf
+  - /usr/local/bin/mount-persistent-storage
   - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", -v, "/mnt/jenkins-ebs:/var/jenkins_home", "jenkins/jenkins-re:latest" ]

--- a/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
+++ b/terraform/cloud-init/master-xenial-16.04-amd64-server.yaml
@@ -228,4 +228,4 @@ runcmd:
   - git clone ${gitrepo} /docker
   - [ docker, build, -t=jenkins/jenkins-re, "/docker/docker" ]
   - /usr/local/bin/mount-xvdf
-  - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", "jenkins/jenkins-re:latest" ]
+  - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", -v, "/mnt/jenkins-ebs:/var/jenkins_home", "jenkins/jenkins-re:latest" ]

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -12,7 +12,7 @@ module "jenkins2_server" {
   subnet_id                   = "${element(module.jenkins2_vpc.public_subnets,0)}"
 
   root_block_device = [{
-    volume_size           = "${var.volume_size}"
+    volume_size           = "${var.server_root_volume_size}"
     delete_on_termination = "true"
   }]
 
@@ -64,7 +64,7 @@ data "template_file" "docker-jenkins2-server-template" {
 
 resource "aws_ebs_volume" "jenkins2_server_storage" {
   availability_zone = "${var.aws_az}"
-  size              = "${var.server_storage_jenkins}"
+  size              = "${var.server_persistent_storage_size}"
   type              = "gp2"
 
   lifecycle {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,6 +49,11 @@ variable "server_name" {
   type        = "string"
 }
 
+variable "server_storage_jenkins" {
+  description = "Persistent Storage for the Jenkins Server"
+  type        = "string"
+}
+
 variable "ubuntu_release" {
   description = "Which version of ubuntu to install"
   type        = "string"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,19 +49,19 @@ variable "server_name" {
   type        = "string"
 }
 
-variable "server_storage_jenkins" {
-  description = "Persistent Storage for the Jenkins Server"
+variable "server_persistent_storage_size" {
+  description = "Size for the persistent storage for the Jenkins Server (GB)"
+  type        = "string"
+  default     = "50"
+}
+
+variable "server_root_volume_size" {
+  description = "Size of the Jenkins Server root volume (GB)"
   type        = "string"
   default     = "50"
 }
 
 variable "ubuntu_release" {
-  description = "Which version of ubuntu to install"
+  description = "Which version of ubuntu to install on Jenkins Server"
   type        = "string"
-}
-
-variable "volume_size" {
-  description = "This defines the default (aws) instance's root volume size."
-  type        = "string"
-  default     = "50"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,6 +52,7 @@ variable "server_name" {
 variable "server_storage_jenkins" {
   description = "Persistent Storage for the Jenkins Server"
   type        = "string"
+  default     = "50"
 }
 
 variable "ubuntu_release" {
@@ -60,7 +61,7 @@ variable "ubuntu_release" {
 }
 
 variable "volume_size" {
-  type        = "string"
   description = "This defines the default (aws) instance's root volume size."
+  type        = "string"
   default     = "50"
 }


### PR DESCRIPTION
There is a need for persistent storage by the master to keep the job history and jenkins specific configuration.

This PR creates a persistent EBS volume that gets attached to the master instance and does not get destroyed between instance re-spins.

The partitioning, formatting and mounting of the EBS volume cannot be managed by cloud-init, because a race condition exists when the instance is created and where cloud-init starts and completes, before the EBS volume is attached and ready for cloud-init to manage. The solution do that is the /usr/local/bin/mount-xvdf script that waits for the attachment of the volume to complete (then formats, configures mount point, then mounts) the EBS volume before starting up the jenkins master docker container.

There is an underlaying issue where re-spinning an instance with the attached EBS volume will fail unless the instance is shutdown or the EBS volume is detached.  This has not been elegantly solved by terraform and bug/feature request exists to solve this problem by having the resource amend terraforms dependancy tree.

This is related to https://github.com/alphagov/re-build-systems-config/pull/5

Solo: @smford 