### PR TITLE
Use a static Jenkins configuration file when building the container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,14 +23,10 @@ RUN chmod +x /start-jenkins.sh
 # copy list of plugins
 COPY files/plugins.txt /usr/share/jenkins/ref/plugins.txt
 
-# set the number of executors
-COPY files/executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
-
 # enable logging
 COPY files/log.properties /usr/share/jenkins/ref/log.properties
 
-# disable security
-#COPY config.xml  /usr/share/jenkins/ref/config.xml
+COPY files/config.xml  /usr/share/jenkins/ref/config.xml
 
 # import jobs
 COPY jobs/ /usr/share/jenkins/ref/jobs/

--- a/docker/files/config.xml
+++ b/docker/files/config.xml
@@ -1,0 +1,38 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.107.3</version>
+  <installState>
+    <isSetupComplete>true</isSetupComplete>
+    <name>RUNNING</name>
+  </installState>
+  <numExecutors>4</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>
+

--- a/docker/files/executors.groovy
+++ b/docker/files/executors.groovy
@@ -1,2 +1,0 @@
-import jenkins.model.*
-Jenkins.instance.setNumExecutors(5)


### PR DESCRIPTION
Before making any particular customisation, we start committing a "vanilla"
config.xml based on the current status of the Jenkins installation.

At some point, we can become more clever and create a template for it, and
pass values, such as the number of executors, ... However, let's keep it
simple and move fast for now.

Now that we use the config.xml file, we don't need to specify the number
of executors as we were doing, thus I removed the file from Dockerfile.

This has been testing by spinning up a Jenkins on my laptop.