### PR TITLE
Enable GitHub Authentication

### DIFF
--- a/docker/files/groovy/configure-github-oauth-jenkins-plugin.groovy
+++ b/docker/files/groovy/configure-github-oauth-jenkins-plugin.groovy
@@ -9,55 +9,70 @@ import org.jenkinsci.plugins.GithubSecurityRealm
 
 def env = System.getenv()
 
-// parameters
-def githubSecurityRealmParameters = [
-  clientID:     env['GITHUB_CLIENT_ID'],
-  clientSecret: env['GITHUB_CLIENT_SECRET'],
-  githubApiUri: 'https://api.github.com',
-  githubWebUri: 'https://github.com',
-  oauthScopes:  'read:org'
-]
+// check github auth details are not blank
+if ((env['GITHUB_CLIENT_ID'] == null) || (env['GITHUB_CLIENT_SECRET'] == null) || (env['GITHUB_ADMIN_USERS'] == null) || (env['GITHUB_ORGANISATIONS'] == null)) {
+  println "GITHUB_CLIENT_ID=${env['GITHUB_CLIENT_ID']}"
+  println "GITHUB_CLIENT_SECRET=${env['GITHUB_CLIENT_SECRET']}"
+  println "GITHUB_ADMIN_USERS=${env['GITHUB_ADMIN_USERS']}"
+  println "GITHUB_ORGANISATIONS=${env['GITHUB_ORGANISATIONS']}"
+  println "Skipping Github Auth configuration, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_ADMIN_USERS or GITHUB_ORGANISTIONS environment variables are blank"
+} else {
+  println "Configuring Github Authentication"
+  println "GITHUB_CLIENT_ID=${env['GITHUB_CLIENT_ID']}"
+  println "GITHUB_CLIENT_SECRET=${env['GITHUB_CLIENT_SECRET']}"
+  println "GITHUB_ADMIN_USERS=${env['GITHUB_ADMIN_USERS']}"
+  println "GITHUB_ORGANISATIONS=${env['GITHUB_ORGANISATIONS']}"
 
-def githubAuthorizationStrategyParameters = [
-  adminUserNames:                         env['GITHUB_ADMIN_USERS'],   // admin User Names
-  allowAnonymousJobStatusPermission:      false,                       // grant ViewStatus permissions for Anonymous Users
-  allowAnonymousReadPermission:           false,                       // grant READ permissions for Anonymous Users
-  allowCcTrayPermission:                  false,                       // grant READ permissions for /cc.xml
-  allowGithubWebHookPermission:           false,                       // grant READ permissions for /github-webhook
-  authenticatedUserCreateJobPermission:   false,                       // grant CREATE Job permissions to all Authenticated Users
-  authenticatedUserReadPermission:        false,                       // grant READ permissions to all Authenticated Users
-  organizationNames:                      env['GITHUB_ORGANISATIONS'], // participant in organizations 
-  useRepositoryPermissions:               true                         // use Github repository permissions
-]
+  // parameters
+  def githubSecurityRealmParameters = [
+    clientID:     env['GITHUB_CLIENT_ID'],
+    clientSecret: env['GITHUB_CLIENT_SECRET'],
+    githubApiUri: 'https://api.github.com',
+    githubWebUri: 'https://github.com',
+    oauthScopes:  'read:org'
+  ]
 
-// https://github.com/jenkinsci/github-oauth-plugin/blob/github-oauth-0.28.1/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
-SecurityRealm githubSecurityRealm = new GithubSecurityRealm(
-  githubSecurityRealmParameters.githubWebUri,
-  githubSecurityRealmParameters.githubApiUri,
-  githubSecurityRealmParameters.clientID,
-  githubSecurityRealmParameters.clientSecret,
-  githubSecurityRealmParameters.oauthScopes
-)
+  def githubAuthorizationStrategyParameters = [
+    adminUserNames:                         env['GITHUB_ADMIN_USERS'],   // admin User Names
+    allowAnonymousJobStatusPermission:      false,                       // grant ViewStatus permissions for Anonymous Users
+    allowAnonymousReadPermission:           false,                       // grant READ permissions for Anonymous Users
+    allowCcTrayPermission:                  false,                       // grant READ permissions for /cc.xml
+    allowGithubWebHookPermission:           false,                       // grant READ permissions for /github-webhook
+    authenticatedUserCreateJobPermission:   false,                       // grant CREATE Job permissions to all Authenticated Users
+    authenticatedUserReadPermission:        false,                       // grant READ permissions to all Authenticated Users
+    organizationNames:                      env['GITHUB_ORGANISATIONS'], // participant in organizations
+    useRepositoryPermissions:               true                         // use Github repository permissions
+  ]
 
-// https://github.com/jenkinsci/github-oauth-plugin/blob/github-oauth-0.28.1/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
-AuthorizationStrategy githubAuthorizationStrategy = new GithubAuthorizationStrategy(
-  githubAuthorizationStrategyParameters.adminUserNames,
-  githubAuthorizationStrategyParameters.authenticatedUserReadPermission,
-  githubAuthorizationStrategyParameters.useRepositoryPermissions,
-  githubAuthorizationStrategyParameters.authenticatedUserCreateJobPermission,
-  githubAuthorizationStrategyParameters.organizationNames,
-  githubAuthorizationStrategyParameters.allowGithubWebHookPermission,
-  githubAuthorizationStrategyParameters.allowCcTrayPermission,
-  githubAuthorizationStrategyParameters.allowAnonymousReadPermission,
-  githubAuthorizationStrategyParameters.allowAnonymousJobStatusPermission
-)
+  // https://github.com/jenkinsci/github-oauth-plugin/blob/github-oauth-0.28.1/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+  SecurityRealm githubSecurityRealm = new GithubSecurityRealm(
+    githubSecurityRealmParameters.githubWebUri,
+    githubSecurityRealmParameters.githubApiUri,
+    githubSecurityRealmParameters.clientID,
+    githubSecurityRealmParameters.clientSecret,
+    githubSecurityRealmParameters.oauthScopes
+  )
 
-// get Jenkins instance
-Jenkins jenkins = Jenkins.getInstance()
+  // https://github.com/jenkinsci/github-oauth-plugin/blob/github-oauth-0.28.1/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+  AuthorizationStrategy githubAuthorizationStrategy = new GithubAuthorizationStrategy(
+    githubAuthorizationStrategyParameters.adminUserNames,
+    githubAuthorizationStrategyParameters.authenticatedUserReadPermission,
+    githubAuthorizationStrategyParameters.useRepositoryPermissions,
+    githubAuthorizationStrategyParameters.authenticatedUserCreateJobPermission,
+    githubAuthorizationStrategyParameters.organizationNames,
+    githubAuthorizationStrategyParameters.allowGithubWebHookPermission,
+    githubAuthorizationStrategyParameters.allowCcTrayPermission,
+    githubAuthorizationStrategyParameters.allowAnonymousReadPermission,
+    githubAuthorizationStrategyParameters.allowAnonymousJobStatusPermission
+  )
 
-// add configuration to Jenkins
-jenkins.setSecurityRealm(githubSecurityRealm)
-jenkins.setAuthorizationStrategy(githubAuthorizationStrategy)
+  // get Jenkins instance
+  Jenkins jenkins = Jenkins.getInstance()
 
-// save current Jenkins state to disk
-jenkins.save()
+  // add configuration to Jenkins
+  jenkins.setSecurityRealm(githubSecurityRealm)
+  jenkins.setAuthorizationStrategy(githubAuthorizationStrategy)
+
+  // save current Jenkins state to disk
+  jenkins.save()
+}

--- a/docker/files/groovy/configure-github-oauth-jenkins-plugin.groovy
+++ b/docker/files/groovy/configure-github-oauth-jenkins-plugin.groovy
@@ -19,15 +19,15 @@ def githubSecurityRealmParameters = [
 ]
 
 def githubAuthorizationStrategyParameters = [
-  adminUserNames:                         env['GITHUB_ADMIN_USERS'], // admin User Names
-  allowAnonymousJobStatusPermission:      false,                     // grant ViewStatus permissions for Anonymous Users
-  allowAnonymousReadPermission:           false,                     // grant READ permissions for Anonymous Users
-  allowCcTrayPermission:                  false,                     // grant READ permissions for /cc.xml
-  allowGithubWebHookPermission:           false,                     // grant READ permissions for /github-webhook
-  authenticatedUserCreateJobPermission:   false,                     // grant CREATE Job permissions to all Authenticated Users
-  authenticatedUserReadPermission:        false,                     // grant READ permissions to all Authenticated Users
-  organizationNames:                      'alphagov',                // participant in Organization
-  useRepositoryPermissions:               true                       // use Github repository permissions
+  adminUserNames:                         env['GITHUB_ADMIN_USERS'],   // admin User Names
+  allowAnonymousJobStatusPermission:      false,                       // grant ViewStatus permissions for Anonymous Users
+  allowAnonymousReadPermission:           false,                       // grant READ permissions for Anonymous Users
+  allowCcTrayPermission:                  false,                       // grant READ permissions for /cc.xml
+  allowGithubWebHookPermission:           false,                       // grant READ permissions for /github-webhook
+  authenticatedUserCreateJobPermission:   false,                       // grant CREATE Job permissions to all Authenticated Users
+  authenticatedUserReadPermission:        false,                       // grant READ permissions to all Authenticated Users
+  organizationNames:                      env['GITHUB_ORGANISATIONS'], // participant in organizations 
+  useRepositoryPermissions:               true                         // use Github repository permissions
 ]
 
 // https://github.com/jenkinsci/github-oauth-plugin/blob/github-oauth-0.28.1/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java

--- a/docker/files/plugins.txt
+++ b/docker/files/plugins.txt
@@ -4,6 +4,9 @@ workflow-aggregator:2.5
 # Github plugin - brings only a bunch of deps
 github:1.29.0
 
+# Github Auth plugin
+github-oauth:0.29
+
 # Docker plugin
 docker-plugin:1.1.4
 

--- a/terraform/cloud-init/server-xenial-16.04-amd64-server.yaml
+++ b/terraform/cloud-init/server-xenial-16.04-amd64-server.yaml
@@ -11,14 +11,6 @@ random_seed:
 locale: en_GB.UTF-8
 write_files:
   - content: |
-      GITHUB_ADMIN_USERS=${github_admin_users}
-      GITHUB_CLIENT_ID=${github_client_id}
-      GITHUB_CLIENT_SECRET=${github_client_secret}
-      GITHUB_ORGANISATIONS=${github_organisations}
-    path: /tmp/gitvars
-    owner: 1000:1000
-    permissions: '0400'
-  - content: |
       #!/usr/bin/env bash
       echo "Waiting until EBS attachment to instance complete"
       while [ ! -e /dev/xvdf ]; do sleep 1; done
@@ -51,6 +43,14 @@ write_files:
       fi
     path: /usr/local/bin/mount-persistent-storage
     permissions: '0555'
+  - content: |
+      GITHUB_ADMIN_USERS=${github_admin_users}
+      GITHUB_CLIENT_ID=${github_client_id}
+      GITHUB_CLIENT_SECRET=${github_client_secret}
+      GITHUB_ORGANISATIONS=${github_organisations}
+    path: '/tmp/gitvars'
+    owner: "ubuntu:ubuntu"
+    permissions: '0400'
 apt_preserve_sources_list: true
 apt_sources:
  - source: "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"

--- a/terraform/cloud-init/server-xenial-16.04-amd64-server.yaml
+++ b/terraform/cloud-init/server-xenial-16.04-amd64-server.yaml
@@ -11,6 +11,14 @@ random_seed:
 locale: en_GB.UTF-8
 write_files:
   - content: |
+      GITHUB_ADMIN_USERS=${github_admin_users}
+      GITHUB_CLIENT_ID=${github_client_id}
+      GITHUB_CLIENT_SECRET=${github_client_secret}
+      GITHUB_ORGANISATIONS=${github_organisations}
+    path: /tmp/gitvars
+    owner: 1000:1000
+    permissions: '0400'
+  - content: |
       #!/usr/bin/env bash
       echo "Waiting until EBS attachment to instance complete"
       while [ ! -e /dev/xvdf ]; do sleep 1; done
@@ -233,4 +241,5 @@ runcmd:
   - git clone ${gitrepo} /docker
   - [ docker, build, -t=jenkins/jenkins-re, "/docker/docker" ]
   - /usr/local/bin/mount-persistent-storage
-  - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", -v, "/mnt/jenkins-ebs:/var/jenkins_home", "jenkins/jenkins-re:latest" ]
+  - [ mv, /tmp/gitvars, /docker/gitvars ]
+  - [ docker, run, --name, myjenkins, -d, -p, "80:80", -p, "50000:50000", --env-file, "/docker/gitvars", -v, "/mnt/jenkins-ebs:/var/jenkins_home", "jenkins/jenkins-re:latest" ]

--- a/terraform/i-server.tf
+++ b/terraform/i-server.tf
@@ -70,12 +70,16 @@ data "template_file" "jenkins2_server_template" {
   template = "${file("cloud-init/server-${var.ubuntu_release}.yaml")}"
 
   vars {
-    awsenv        = "${var.environment}"
-    dockerversion = "${var.dockerversion}"
-    fqdn          = "${var.server_name}.${var.hostname_suffix}"
-    gitrepo       = "${var.gitrepo}"
-    hostname      = "${var.server_name}.${var.hostname_suffix}"
-    region        = "${var.aws_region}"
+    awsenv               = "${var.environment}"
+    dockerversion        = "${var.dockerversion}"
+    fqdn                 = "${var.server_name}.${var.hostname_suffix}"
+    gitrepo              = "${var.gitrepo}"
+    hostname             = "${var.server_name}.${var.hostname_suffix}"
+    region               = "${var.aws_region}"
+    github_admin_users   = "${join(",", var.github_admin_users)}"
+    github_client_id     = "${var.github_client_id}"
+    github_client_secret = "${var.github_client_secret}"
+    github_organisations = "${join(",", var.github_organisations)}"
   }
 }
 

--- a/terraform/i-server.tf
+++ b/terraform/i-server.tf
@@ -28,17 +28,17 @@ module "jenkins2_server" {
 # the terraform-aws-modules/ec2-instance/aws module then it will be the DNS name that resolves to the original IPv4 address assigned to the EC2, rather than
 # the eip. This may be resolved in Terraform (using an export from aws_eip) in the future at which point this code can be removed (see
 # https://github.com/terraform-providers/terraform-provider-aws/issues/1149).
-resource "null_resource" "get_public_dns_name" {
-  triggers {
-    cluster_instance_ids = "${join(",", module.jenkins2_server.id)}"
-  }
-
-  depends_on = ["module.jenkins2_server"]
-
-  provisioner "local-exec" {
-    command = "echo 'public_dns name = ' && /usr/local/bin/aws ec2 describe-instances --instance-ids ${join(" ", module.jenkins2_server.id)} --query 'Reservations[].Instances[].PublicDnsName'"
-  }
-}
+#resource "null_resource" "get_public_dns_name" {
+#  triggers {
+#    cluster_instance_ids = "${join(",", module.jenkins2_server.id)}"
+#  }
+#
+#  depends_on = ["module.jenkins2_server"]
+#
+#  provisioner "local-exec" {
+#    command = "echo 'public_dns name = ' && /usr/local/bin/aws ec2 describe-instances --instance-ids ${join(" ", module.jenkins2_server.id)} --query 'Reservations[].Instances[].PublicDnsName'"
+#  }
+#}
 
 data "aws_ami" "source" {
   most_recent = true

--- a/terraform/i-server.tf
+++ b/terraform/i-server.tf
@@ -8,7 +8,7 @@ module "jenkins2_server" {
   user_data                   = "${data.template_file.jenkins2_server_template.rendered}"
   key_name                    = "jenkins2_key_${var.product}-${var.environment}"
   monitoring                  = true
-  vpc_security_group_ids      = ["${module.jenkins2_sg_server_internet_facing.this_security_group_id}", "${module.jenkins2_sg_server_private_facing.this_security_group_id}"]
+  vpc_security_group_ids      = ["${module.jenkins2_sg_server_internet_facing.this_security_group_id}", "${module.jenkins2_sg_server_private_facing.this_security_group_id}", "${module.jenkins2_sg_cloudflare.this_security_group_id}"]
   subnet_id                   = "${element(module.jenkins2_vpc.public_subnets,0)}"
 
   root_block_device = [{

--- a/terraform/sg-cloudflare.tf
+++ b/terraform/sg-cloudflare.tf
@@ -1,0 +1,11 @@
+module "jenkins2_sg_cloudflare" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "1.22.0"
+
+  name        = "jenkins2_sg_cloudflare_${var.product}_${var.environment}_cloudflare"
+  description = "Jenkins2 Security Group Allowing HTTP - Cloudflare"
+  vpc_id      = "${module.jenkins2_vpc.vpc_id}"
+
+  ingress_cidr_blocks = ["${var.cloudflare_ips}"]
+  ingress_rules       = ["https-443-tcp", "http-80-tcp"]
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -11,6 +11,16 @@ aws_profile = "re-build-systems"
 
 dockerversion = "18.03.1~ce-0~ubuntu"
 
+github_admin_users = [
+  "admin1",
+  "admin2",
+  "admin3",
+]
+
+github_client_id = "abcdefghij"
+
+github_client_secret = "0123456789"
+
 gitrepo = "https://github.com/alphagov/re-build-systems.git"
 
 hostname_suffix = "build.example.com"
@@ -32,4 +42,3 @@ worker_instance_type = "t2.medium"
 worker_name = "worker"
 
 worker_root_volume_size = "50"
-

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,6 +24,30 @@ variable "environment" {
   type        = "string"
 }
 
+variable "github_admin_users" {
+  description = "List of Github admin users."
+  type        = "list"
+  default     = []
+}
+
+variable "github_client_id" {
+  description = "Your Github client Id"
+  type        = "string"
+  default     = ""
+}
+
+variable "github_client_secret" {
+  description = "Your Github client secret"
+  type        = "string"
+  default     = ""
+}
+
+variable "github_organisations" {
+  description = "List of Github organisations."
+  type        = "list"
+  default     = []
+}
+
 variable "gitrepo" {
   type = "string"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,6 +14,28 @@ variable "aws_region" {
   type = "string"
 }
 
+variable "cloudflare_ips" {
+  description = "Allowed Cloudflare IP Addresses"
+  type        = "list"
+
+  default = [
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "104.16.0.0/12",
+    "108.162.192.0/18",
+    "131.0.72.0/22",
+    "141.101.64.0/18",
+    "162.158.0.0/15",
+    "172.64.0.0/13",
+    "173.245.48.0/20",
+    "188.114.96.0/20",
+    "190.93.240.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+  ]
+}
+
 variable "dockerversion" {
   description = "Docker version to install"
   type        = "string"


### PR DESCRIPTION
Enable Github Authentication

- installs github-oauth plugin in to jenkins
- exposes the necessary variables needed to  configure github auth
- installs a configuration script, that if not given secrets will not configure github auth
- enables cloudflare connections inwards (whilst development work on DNS and SSL continues)
- temporarily disable an erroneous output

The github secrets needed for github auth can be passed as a variable when running terraform.

Pair: @smford & @poveyd