### PR TITLE
Allow user to specify which SSH public key file to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Architectural documentation is available [here](docs/architecture/README.md).
     ```
     terraform apply \
         -var-file=../../re-build-systems-config/terraform/terraform.tfvars  \
-        -var environment=$JENKINS_ENV_NAME
+        -var environment=$JENKINS_ENV_NAME \
+        -var ssh_public_key_file=[path to your public ssh key]
     ```
 
     You may want to take note of these values from the output of the previous command - they can be helpful for debugging:

--- a/terraform/ssh-keys.tf
+++ b/terraform/ssh-keys.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "deployer-ssh-key" {
   key_name   = "jenkins2_key_${var.team_name}_${var.environment}"
-  public_key = "${file("../../${var.team_name}-config/terraform/keys/${var.environment}-ssh-deployer.pub")}"
+  public_key = "${file("${ssh_public_key_file}")}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,6 +55,10 @@ variable "public_subnet" {
   default = "10.0.101.0/24"
 }
 
+variable "ssh_public_key_file" {
+  type = "string"
+}
+
 # #### Team preferences ####
 
 variable "environment" {


### PR DESCRIPTION
Rather than computing the path to the public ssh key which is highly opinionated, this change allows a user to specify a public ssh key to use.

Solo: @smford