### PR TITLE
Wrap up documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+* [Architectural overview](architecture/README.md)
+* [Documentation for product team](docs_for_team/README.md)
+* [Documentation for Reliability Engineering](docs_for_re/README.md)

--- a/docs/docs_for_re/README.md
+++ b/docs/docs_for_re/README.md
@@ -1,2 +1,35 @@
 # Documentation for Reliability Engineering
 
+Once the product team completes the provisioning of the DNS, they are going to contact
+Reliability Engineering (RE).
+
+At that point, RE will need to do 3 things:
+
+* "Enable" the team DNS
+
+* Create a Github OAuth app
+
+* Provide the app credentials to the product team
+
+## Enable team DNS
+
+Documentation can be found [here](https://github.com/alphagov/re-build-systems-dns)
+
+## Create a Github OAuth app
+
+This allows the product team to setup authentication to the Jenkins via Github OAuth.
+
+An app needs to be created for each environment (and therefore URL) the team created. Use these settings (placeholders you need to replace are in square brackets):
+
+* Application name:  re-build-auth-app-[team name]-[environment] , e.g. `re-build-auth-app-eidas-dev`
+
+* Homepage URL:  [URL]
+
+* Application description:  Build system for [URL]
+
+* Authorization callback URL:  [URL]/securityRealm/finishLogin
+
+## Provide the app credentials to the product team
+
+For each app you created, provide the `id` and `secret` to the product team, so that
+they can complete the provisioning of their Jenkins.

--- a/docs/docs_for_re/README.md
+++ b/docs/docs_for_re/README.md
@@ -1,0 +1,2 @@
+# Documentation for Reliability Engineering
+

--- a/docs/docs_for_team/README.md
+++ b/docs/docs_for_team/README.md
@@ -1,0 +1,2 @@
+# Documentation for the product team
+

--- a/docs/docs_for_team/README.md
+++ b/docs/docs_for_team/README.md
@@ -1,2 +1,80 @@
 # Documentation for the product team
 
+## Provisioning of the Jenkins
+
+Documentation is in [the main README of the repo](https://github.com/alphagov/re-build-systems-dns).
+
+## How to set up a job using Jenkinsfile
+
+This is an [example of a project](https://github.com/alphagov/re-build-systems-sample-java-app/tree/jenkinsfile-supported-by-re-build-mvp) that can be built using this Jenkins platform.
+
+It shows how to structure the Jenkinsfile - the most important part is this:
+
+```
+agent {
+    label 'docker-jnlp-java-agent'
+}
+```
+
+`docker-jnlp-java-agent` is an the Docker  image you define in Jenkins, via
+'Manage Jenkins' -> 'Configure system' -> 'Cloud' -> 'Add a new cloud'.
+The settings are:
+
+* Name: docker-worker-2-java
+* Docker Host URI: tcp://worker:2375
+* Label: docker-jnlp-java-agent
+* Docker image: [builder-docker-image-url]
+* Remote filesystem root: /home/jenkins
+* Connect method: Attach Docker container
+
+That can also be done via a Groovy script.
+
+`builder-docker-image-url` is the URL of the Docker image which is going to build the code (for example, it may be hosted on Dockerhub).
+
+The way you build the image is by inheriting from the `jenkins/jnlp-slave` base image and install
+your development tools on top of it.
+
+This is an example of a builder Docker image for Maven (bear in mind that the Jenkins slave image installs Java8):
+
+```
+FROM jenkins/jnlp-slave
+
+ARG user=jenkins
+
+USER root
+
+# install Maven
+
+ARG MAVEN_VERSION=3.5.3
+ARG USER_HOME_DIR="/root"
+ARG SHA=b52956373fab1dd4277926507ab189fb797b3bc51a2a267a193c931fffad8408
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+    apt-get install -y \
+      curl procps \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+USER ${user}
+
+ENV LC_ALL en_GB.UTF-8
+CMD ["/bin/bash"]
+```
+
+Then, the last part is to create a new job that will use the Jenkinsfile of the repository.
+From Jenkins, 'New item' -> 'Pipeline'. Then, the settings are as follows:
+
+* Github project URL: [git-repo-url]
+* Pipeline Definition: Pipeline script from SCM Pipeline
+* SCM: Git
+* Pipeline Repository URL: [git-repo-url]


### PR DESCRIPTION
Add some documentation to wrap up the mission. It is not perfect, it may need a review to improve English and usability. That can be done later on, I feel this is a good start, given the time constraints, resources and other priorities.

In particular it adds:
* documentation for RE on how to deal with a request when the team finished the DNS provisioning
* documentation for the service team on how to use our current MVP to build code.