### PR TITLE
Add bucket name validation on creation

### DIFF
--- a/terraform/tools/create-s3-state-bucket
+++ b/terraform/tools/create-s3-state-bucket
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -ef -o pipefail
 
-AWS_REGION="${AWS_REGION:-eu-west-2}"
+AWS_REGION="${AWS_DEFAULT_REGION:-eu-west-2}"
 
 function print_help_and_exit() {
+  [ "$1" ] && echo "$1"
+  [ "$1" ] && echo ""
   echo "Creates an S3 bucket to store .tfstate files"
   echo ""
   echo "$0 -t <team name> -e <environment> -p <aws profile>"
@@ -11,13 +13,15 @@ function print_help_and_exit() {
   echo "<team name>        = team name"
   echo "<environment>      = prod, staging, test, etc"
   echo "<aws profile>      = aws profile name from ~/.aws/credentials"
+  echo ""
+  echo "Note that the -d and -t parameters must only contain letters, numbers, dots (.) and dashes (-)."
   exit 1
 }
 
 function check_arguments () {
-  [ "${TEAMNAME}" ] || print_help_and_exit
-  [ "${ENVIRONMENT}" ] || print_help_and_exit
-  [ "${AWS_PROFILE}" ] || print_help_and_exit
+  [ "${TEAMNAME}" ] || print_help_and_exit "Please specify the -t parameter"
+  [ "${ENVIRONMENT}" ] || print_help_and_exit "Please specify the -e parameter"
+  [ "${AWS_PROFILE}" ] || print_help_and_exit "Please specify the -p parameter"
 }
 
 while getopts "t:e:p:" arg; do
@@ -35,6 +39,10 @@ while getopts "t:e:p:" arg; do
 done
 
 check_arguments
+
+[[ "$ENVIRONMENT" =~ ^[a-zA-Z0-9.\-]{1,255}$ ]] || print_help_and_exit "The -e parameter must only contain letters, numbers, dots (.) and dashes (-)"
+[[ "$TEAMNAME" =~ ^[a-zA-Z0-9.\-]{1,255}$ ]] || print_help_and_exit "The -t parameter must only contain letters, numbers, dots (.) and dashes (-)"
+
 echo "Creating terraform state bucket tfstate-${TEAMNAME}-${ENVIRONMENT} in ${AWS_REGION}"
 aws s3api create-bucket --bucket "tfstate-${TEAMNAME}-${ENVIRONMENT}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}" --profile "${AWS_PROFILE}"
 echo "Enabling bucket versioning on tfstate-${TEAMNAME}-${ENVIRONMENT} in ${AWS_REGION}"

--- a/terraform_dns/terraform.tfvars.example
+++ b/terraform_dns/terraform.tfvars.example
@@ -1,18 +1,18 @@
-### USER SETTINGS ###
+### CUSTOM USER SETTINGS - change these values for your custom Jenkins ###
 
-# refer to the user manual for the value to set here
-top_level_domain_name = "Add in your domain name here, for example: build.example.com"
-
+# The name of your team that will be part of your URLs
 team_name = "Add in the name of your team here, for example: team2"
 
+# The name of the environments you want to provision Jenkins for, you can call these whatever you like. We've given some examples here.
 team_environments = [
   "dev",
   "staging",
   "prod",
 ]
 
+### STANDARD SETTINGS - you shouldn't need to change these ###
 
-### AWS SETTINGS ###
+top_level_domain_name = "build.gds-reliability.engineering"
 
 aws_az = "eu-west-2a"
 

--- a/terraform_dns/terraform.tfvars.example
+++ b/terraform_dns/terraform.tfvars.example
@@ -1,9 +1,9 @@
 ### USER SETTINGS ###
 
 # refer to the user manual for the value to set here
-top_level_domain_name = "build.example.com"
+top_level_domain_name = "Add in your domain name here, for example: build.example.com"
 
-team_name = "team2"
+team_name = "Add in the name of your team here, for example: team2"
 
 team_environments = [
   "dev",

--- a/terraform_dns/tools/create-dns-s3-state-bucket
+++ b/terraform_dns/tools/create-dns-s3-state-bucket
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -ef -o pipefail
 
-AWS_REGION="${AWS_REGION:-eu-west-2}"
+AWS_REGION="${AWS_DEFAULT_REGION:-eu-west-2}"
 
 function print_help_and_exit() {
+  [ "$1" ] && echo "$1"
+  [ "$1" ] && echo ""
   echo "Creates an S3 bucket to store .tfstate files"
   echo ""
   echo "$0 -d <domain name> -p <aws profile> -t <team name>"
@@ -11,13 +13,15 @@ function print_help_and_exit() {
   echo "<domain name>      = domain name"
   echo "<aws profile>      = aws profile name from ~/.aws/credentials"
   echo "<team name>        = name of the team owning the Dockerised Jenkins"
+  echo ""
+  echo "Note that the -d and -t parameters must only contain letters, numbers, dots (.) and dashes (-)."
   exit 1
 }
 
 function check_arguments () {
-  [ "${DOMAINNAME}" ] || print_help_and_exit
-  [ "${AWS_PROFILE}" ] || print_help_and_exit
-  [ "${TEAM_NAME}" ] || print_help_and_exit
+  [ "${DOMAINNAME}" ] || print_help_and_exit "Please specify the -d parameter"
+  [ "${AWS_PROFILE}" ] || print_help_and_exit "Please specify the -p parameter"
+  [ "${TEAMNAME}" ] || print_help_and_exit "Please specify the -t parameter"
 }
 
 while getopts "d:p:t:" arg; do
@@ -29,13 +33,17 @@ while getopts "d:p:t:" arg; do
       AWS_PROFILE="${OPTARG}"
       ;;
     t)
-      TEAM_NAME="${OPTARG}"
+      TEAMNAME="${OPTARG}"
       ;;
   esac
 done
 
 check_arguments
-echo "Creating terraform state bucket tfstate-dns-${TEAM_NAME}.${DOMAINNAME} in ${AWS_REGION}"
-aws s3api create-bucket --bucket "tfstate-dns-${TEAM_NAME}.${DOMAINNAME}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}" --profile "${AWS_PROFILE}"
-echo "Enabling bucket versioning on tfstate-dns-${TEAM_NAME}.${DOMAINNAME} in ${AWS_REGION}"
-aws s3api put-bucket-versioning --bucket "tfstate-dns-${TEAM_NAME}.${DOMAINNAME}" --region "${AWS_REGION}" --versioning-configuration Status=Enabled --profile "${AWS_PROFILE}"
+
+[[ "$DOMAINNAME" =~ ^[a-zA-Z0-9.\-]{1,255}$ ]] || print_help_and_exit "The -d parameter must only contain letters, numbers, dots (.) and dashes (-)"
+[[ "$TEAMNAME" =~ ^[a-zA-Z0-9.\-]{1,255}$ ]] || print_help_and_exit "The -t parameter must only contain letters, numbers, dots (.) and dashes (-)"
+
+echo "Creating terraform state bucket tfstate-dns-${TEAMNAME}.${DOMAINNAME} in ${AWS_REGION}"
+aws s3api create-bucket --bucket "tfstate-dns-${TEAMNAME}.${DOMAINNAME}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}" --profile "${AWS_PROFILE}"
+echo "Enabling bucket versioning on tfstate-dns-${TEAMNAME}.${DOMAINNAME} in ${AWS_REGION}"
+aws s3api put-bucket-versioning --bucket "tfstate-dns-${TEAMNAME}.${DOMAINNAME}" --region "${AWS_REGION}" --versioning-configuration Status=Enabled --profile "${AWS_PROFILE}"


### PR DESCRIPTION
Change bucket creation scripts, and terraform.tfvars_example, to fail fast when invalid characters passed in. These invalid characters are not allowed in S3 bucket names and will prevent AWS creating an S3 bucket.