### PR TITLE
Restrict Agent-to-Master Access Control

### DIFF
--- a/docker/files/groovy/configure-slave-to-master-access.groovy
+++ b/docker/files/groovy/configure-slave-to-master-access.groovy
@@ -1,0 +1,4 @@
+import jenkins.security.s2m.AdminWhitelistRule
+import jenkins.model.Jenkins
+Jenkins.instance.getInjector().getInstance(AdminWhitelistRule.class)
+.setMasterKillSwitch(false)


### PR DESCRIPTION
This enables Agent-to-Master access control, it means access to worker nodes can be selective and removes a security warning.

By being selective it means that varying levels of access control can be granted to the slaves, rather than having the slaves have full control over the jenkins master.

Further documentation is available here: https://wiki.jenkins.io/display/JENKINS/Slave+To+Master+Access+Control

Solo: @smford