### PR TITLE
Modify documentation for RE

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ For this step, you will need to choose:
 
    For each environment you define, a new URL will be created in the form:
 
-   `https://[team_environments].[team_name].gds-reliability.engineering`
+   `https://[team_environments].[team_name].build.gds-reliability.engineering`
 
    So, if you choose `team_environments = ["dev", "staging"]` and `team_name = "my-team"`, the following URLs will be created:
 
-   `https://dev.my-team.gds-reliability.engineering` and `https://staging.my-team.gds-reliability.engineering`
+   `https://dev.my-team.build.gds-reliability.engineering` and `https://staging.my-team.build.gds-reliability.engineering`
 
 1. Export the `team_name` as a variable to use when running the DNS Terraform
 

--- a/docs/docs_for_re/README.md
+++ b/docs/docs_for_re/README.md
@@ -19,15 +19,23 @@ Documentation can be found [here](https://github.com/alphagov/re-build-systems-d
 
 This allows the product team to setup authentication to the Jenkins via Github OAuth.
 
-An app needs to be created for each environment (and therefore URL) the team created. Use these settings (placeholders you need to replace are in square brackets):
+An app needs to be created for each environment (and therefore URL) the team created.
 
-* Application name:  re-build-auth-app-[team name]-[environment] , e.g. `re-build-auth-app-eidas-dev`
+Use the following settings to setup your app. Any fields or options that are not mentioned here can be left blank or with their default value.
+
+The [URL] will follow the pattern `https://[environment].[team_name].build.gds-reliability.engineering`.
+
+* GitHub App name:  `re-build-auth-[team name]-[environment]` , e.g. `re-build-auth-app-eidas-dev`. You may have to deviate from this format if it exceeds 34 characters.
+
+* Description:  Build system for [URL]
 
 * Homepage URL:  [URL]
 
-* Application description:  Build system for [URL]
+* User authorization callback URL:  [URL]/securityRealm/finishLogin
 
-* Authorization callback URL:  [URL]/securityRealm/finishLogin
+* Webhook URL: [URL]
+
+* Permissions > Organization members: `Access: Read-only`
 
 ## Provide the app credentials to the product team
 


### PR DESCRIPTION
Documentation for Reliability Engineering didn't reflect the complete process, so it wasn't possible to follow.

For example, there were fields missing that had to be filled in.

Also, the URL structure in both RE and end-user docs was wrong, so I had to make most changes in the RE docs, but small changes in the end-user docs too.

May need further editing.