### PR TITLE
Make the RE build domain public

### DIFF
--- a/terraform/jenkins/terraform.tfvars.example
+++ b/terraform/jenkins/terraform.tfvars.example
@@ -30,7 +30,7 @@ gitrepo = "https://github.com/alphagov/re-build-systems.git"
 
 gitrepo_branch = "master"
 
-hostname_suffix = "build.example.com"
+hostname_suffix = "build.gds-reliability.engineering"
 
 server_instance_type = "t2.small"
 


### PR DESCRIPTION
We decided that build.gds-reliability.engineering domain can be publicly disclosed.
We changed the README accordingly but we forgot to change this config file