### PR TITLE
Prevent jobs running on the jenkins master

### DIFF
--- a/docker/files/groovy/configure-number-of-executors.groovy
+++ b/docker/files/groovy/configure-number-of-executors.groovy
@@ -1,2 +1,2 @@
 import jenkins.model.*
-Jenkins.instance.setNumExecutors(5)
+Jenkins.instance.setNumExecutors(0)


### PR DESCRIPTION
Set the number of executors to 0, which prevents jobs running on the master.

Solo: @smford