### PR TITLE
Fix confusing internal DNS naming scheme

### DIFF
--- a/terraform/jenkins/asg.tf
+++ b/terraform/jenkins/asg.tf
@@ -37,6 +37,7 @@ data "template_file" "jenkins2_asg_server_template" {
     gitrepo_branch       = "${var.gitrepo_branch}"
     hostname             = "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
     region               = "${var.aws_region}"
+    team                 = "${var.team_name}"
     github_admin_users   = "${join(",", var.github_admin_users)}"
     github_client_id     = "${var.github_client_id}"
     github_client_secret = "${var.github_client_secret}"
@@ -85,7 +86,7 @@ resource "aws_autoscaling_group" "asg_jenkins2_server" {
 resource "aws_elb" "elb_jenkins2_server" {
   name = "elb-${var.server_name}-${var.environment}-${var.team_name}"
 
-  security_groups    = ["${module.jenkins2_sg_asg_server_internet_facing.this_security_group_id}", "${module.jenkins2_sg_asg_server_internal.this_security_group_id}"]
+  security_groups = ["${module.jenkins2_sg_asg_server_internet_facing.this_security_group_id}", "${module.jenkins2_sg_asg_server_internal.this_security_group_id}"]
 
   subnets = ["${element(module.jenkins2_vpc.public_subnets,0)}"]
 

--- a/terraform/jenkins/cloud-init/server-asg-xenial-16.04-amd64-server.yaml
+++ b/terraform/jenkins/cloud-init/server-asg-xenial-16.04-amd64-server.yaml
@@ -197,9 +197,9 @@ apt_sources:
 bootcmd:
   - [ sh, -c, echo "Starting Jenkins2 Master Server" ]
 runcmd:
-  - echo "append domain-search \"${awsenv}.internal\";" >> /etc/dhcp/dhclient.conf
+  - echo "append domain-search \"${awsenv}.${team}.internal\";" >> /etc/dhcp/dhclient.conf
   - dhclient -r; dhclient
-  - echo "search ${awsenv}.internal" >> /etc/resolvconf/resolv.conf.d/base
+  - echo "search ${awsenv}.${team}.internal" >> /etc/resolvconf/resolv.conf.d/base
   - [ apt-get, update ]
   - [ apt-get, upgrade ]
   - apt-get install -y docker-ce=${dockerversion}

--- a/terraform/jenkins/cloud-init/worker-xenial-16.04-amd64-server.yaml
+++ b/terraform/jenkins/cloud-init/worker-xenial-16.04-amd64-server.yaml
@@ -203,9 +203,9 @@ write_files:
 bootcmd:
   - [ sh, -c, echo "Starting Jenkins2 Worker Server" ]
 runcmd:
-  - echo "append domain-search \"${awsenv}.internal\";" >> /etc/dhcp/dhclient.conf
+  - echo "append domain-search \"${awsenv}.${team}.internal\";" >> /etc/dhcp/dhclient.conf
   - dhclient -r; dhclient
-  - echo "search ${awsenv}.internal" >> /etc/resolvconf/resolv.conf.d/base
+  - echo "search ${awsenv}.${team}.internal" >> /etc/resolvconf/resolv.conf.d/base
   - [ apt-get, update ]
   - [ apt-get, upgrade ]
   - apt-get install -y docker-ce=${dockerversion}

--- a/terraform/jenkins/dns.tf
+++ b/terraform/jenkins/dns.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "private_facing" {
-  name   = "${var.environment}.internal"
+  name   = "${var.environment}.${var.team_name}.internal"
   vpc_id = "${module.jenkins2_vpc.vpc_id}"
 
   tags {

--- a/terraform/jenkins/i-worker.tf
+++ b/terraform/jenkins/i-worker.tf
@@ -10,6 +10,7 @@ module "jenkins2_worker" {
   monitoring                  = true
   vpc_security_group_ids      = ["${module.jenkins2_sg_worker.this_security_group_id}"]
   subnet_id                   = "${element(module.jenkins2_vpc.public_subnets,0)}"
+  team                        = "${var.team_name}"
 
   root_block_device = [{
     volume_size           = "${var.worker_root_volume_size}"

--- a/terraform/jenkins/i-worker.tf
+++ b/terraform/jenkins/i-worker.tf
@@ -10,7 +10,6 @@ module "jenkins2_worker" {
   monitoring                  = true
   vpc_security_group_ids      = ["${module.jenkins2_sg_worker.this_security_group_id}"]
   subnet_id                   = "${element(module.jenkins2_vpc.public_subnets,0)}"
-  team                        = "${var.team_name}"
 
   root_block_device = [{
     volume_size           = "${var.worker_root_volume_size}"
@@ -34,6 +33,7 @@ data "template_file" "jenkins2_worker_template" {
     fqdn          = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
     hostname      = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
     region        = "${var.aws_region}"
+    team          = "${var.team_name}"
   }
 }
 


### PR DESCRIPTION
The Route 53 records for the internal dns are in the form:
[environment].internal

This causes confusion when multiple teams use the same environment name and the same aws account.  By adding team name to the internal dns zone it removes the confusion, resulting in:
[environment].[team].internal

Solo: @smford