### PR TITLE
Remove concept of environments from dns terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,6 @@ For this step, you will need to choose:
 
 1. Go into the `terraform.tfvars` file you just renamed and customise the user settings under `### CUSTOM USER SETTINGS ###`.
 
-   For each environment you define, a new URL will be created in the form:
-
-   `https://[team_environments].[team_name].build.gds-reliability.engineering`
-
-   So, if you choose `team_environments = ["dev", "staging"]` and `team_name = "my-team"`, the following URLs will be created:
-
-   `https://dev.my-team.build.gds-reliability.engineering` and `https://staging.my-team.build.gds-reliability.engineering`
-
 1. Export the `team_name` as a variable to use when running the DNS Terraform
 
     ```

--- a/terraform/dns/terraform.tfvars.example
+++ b/terraform/dns/terraform.tfvars.example
@@ -1,16 +1,7 @@
 ### CUSTOM USER SETTINGS - change these values for your custom Jenkins ###
 
-# The name of your team that will be part of your URLs
-team_name = "Add in the name of your team here, for example: team2"
-
-# The name of the environments you want to provision Jenkins for, you can call these whatever you like. We've given some examples here.
-team_environments = [
-  "dev",
-  "staging",
-  "prod",
-]
-
-### STANDARD SETTINGS - you shouldn't need to change these ###
+# The name of your team that will become part of your URL
+team_name = "your-team-name"
 
 top_level_domain_name = "build.gds-reliability.engineering"
 

--- a/terraform/dns/terraform.tfvars.example
+++ b/terraform/dns/terraform.tfvars.example
@@ -1,7 +1,9 @@
 ### CUSTOM USER SETTINGS - change these values for your custom Jenkins ###
 
 # The name of your team that will become part of your URL
-team_name = "your-team-name"
+team_name = "Add in the name of your team here, for example: your-team-name"
+
+### STANDARD SETTINGS - you shouldn't need to change these ###
 
 top_level_domain_name = "build.gds-reliability.engineering"
 


### PR DESCRIPTION
Environments are no longer needed now that we no longer use EIPS.

This removes old references to it and updates the documentation.

Solo: @smford