### PR TITLE
Documentation tweaks 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For this step, you will need to choose:
    Run this command from the `terraform/dns/tools` directory:
 
     ```
-    ./tools/create-dns-s3-state-bucket \
+    ./create-dns-s3-state-bucket \
         -d build.gds-reliability.engineering \
         -p re-build-systems \
         -t $JENKINS_TEAM_NAME

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This step needs to be done for each environment you defined in STEP 1 (e.g. `dev
 
     In order to initialise the S3 bucket we have created with Terraform, we need to export some secrets.
 
-    You did this in the `Run DNS Terraform` section of this guidance, so you only need to carry out this step if you ended your terminal session since you carried out that step.
+    You did this in the `DNS provisioning` section of this guidance, so you only need to carry out this step if you ended your terminal session since you carried out that step.
 
     ```
     export AWS_ACCESS_KEY_ID="[aws key]"


### PR DESCRIPTION
- Fix wrong path for one of the commands to run.
- Remove the reference to a subsection we removed previously.