### PR TITLE
Make it more difficult to miss an important config value that needs to be customised.

### DIFF
--- a/terraform/jenkins/terraform.tfvars.example
+++ b/terraform/jenkins/terraform.tfvars.example
@@ -8,6 +8,9 @@ allowed_ips = [
   "ww.xx.yy.zz/32",
 ]
 
+# The team_name you defined earlier
+team_name = "your-team-name"
+
 # The client ID you were given when the GitHub OAuth app was created
 github_client_id = "aabbccddee"
 
@@ -29,10 +32,6 @@ github_admin_users = [
 
 # The suffix of the URL that you setup earlier. If you're in GDS you may not have to change this
 hostname_suffix = "build.gds-reliability.engineering"
-
-# The team_name you defined earlier
-team_name = "team2"
-
 
 ### STANDARD SETTINGS - you shouldn't need to change these ###
 


### PR DESCRIPTION
It happened to me that I missed to change the `team_name` variable
in the terraform configuration file, because it was at the bottom,
after a variable that did not need to be changed (so I thought I was done).
The provisioning of the environment failed and it took me a while to understand why.
I have moved the variable to a more prominent place.