### PR TITLE
Move Github OAuth docs from RE side to Team side, and avoid storing Github creds in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For this step, you will need to choose your team name, which will be part of the
 
 1. Add your AWS user credentials to `~/.aws/credentials`
 
-  If this file does not exist, create it first.
+    If this file does not exist, create it first.
 
     ```
     [re-build-systems]
@@ -121,12 +121,8 @@ For this step, you will need to choose your team name, which will be part of the
     ]
     ```
 
-    Copy and send this output to the GDS Reliability Engineering team.
-
-    The Reliability Engineering team will make your URL live and set up your Github OAuth so you can log in to your Jenkins.
-
+    Copy and send this output to the GDS Reliability Engineering team, which will make your URL live.
     This step may take up to two working days.
-
 
 
 
@@ -139,12 +135,44 @@ In this step you will provision all the infrastructure needed to run your Jenkin
 For this step, you will need to choose which environment you want to set up Jenkins for
 (e.g. `ci`, `dev`, `staging`) - that will be part of the URL of your Jenkins.
 
-1. Export the environment and team names, as you set them during the provisioning of the DNS:
+1. Export the environment name you have chosen, and the team name you set during the provisioning of the DNS:
 
     ```
     export JENKINS_ENV_NAME=[environment-name]
     export JENKINS_TEAM_NAME=[team-name]
     ```
+
+1. Create a Github OAuth app
+
+    This allows to setup authentication to the Jenkins via Github.
+
+    Go to the [Register a new OAuth application](https://github.com/settings/applications/new) page and use the following settings to setup your app.
+
+    The [URL] will follow the pattern `https://jenkins2.[environment-name].[team-name].build.gds-reliability.engineering`.
+
+    * Application name:  `re-build-auth-[team name]-[environment name]` , e.g. `re-build-auth-app-eidas-dev`. You may have to deviate from this format if it exceeds 34 characters.
+
+    * Homepage URL:  [URL]
+
+    * Application description:  Build system for [URL]
+
+    * Authorization callback URL:  [URL]/securityRealm/finishLogin
+
+    Then, click the 'Register application' button.
+
+    Export the credentials as they appear on the screen:
+
+    ```
+    export JENKINS_GITHUB_OAUTH_ID=[client-id]
+    export JENKINS_GITHUB_OAUTH_SECRET=[client-secret]
+    ```
+
+1. Transfer ownership of the Github OAuth app
+
+    Skip this step if you are provisioning the platform only for test or development purpose.
+
+    Otherwise you should transfer ownership of the app to `alphagov`.\
+    To do so, click the "Transfer ownership" button located at the top of the page where you copied the credentials from. Input `alphagov` as organisation.
 
 1. Generate an SSH key pair in a location of your choice.
 
@@ -200,6 +228,8 @@ For this step, you will need to choose which environment you want to set up Jenk
     terraform apply \
         -var-file=./terraform.tfvars  \
         -var environment=$JENKINS_ENV_NAME \
+        -var github_client_id=$JENKINS_GITHUB_OAUTH_ID \
+        -var github_client_secret=$JENKINS_GITHUB_OAUTH_SECRET \
         -var ssh_public_key_file=~/.ssh/build_systems_${JENKINS_TEAM_NAME}_${JENKINS_ENV_NAME}_rsa.pub
     ```
 

--- a/docs/docs_for_re/README.md
+++ b/docs/docs_for_re/README.md
@@ -3,41 +3,10 @@
 Once the product team completes the provisioning of the DNS, they are going to contact
 Reliability Engineering (RE).
 
-At that point, RE will need to do 3 things:
-
-* "Enable" the team DNS
-
-* Create a Github OAuth app
-
-* Provide the app credentials to the product team
+At that point, RE will need to "enable" the team DNS
 
 ## Enable team DNS
 
 Documentation can be found [here](https://github.com/alphagov/re-build-systems-dns)
 
-## Create a Github OAuth app
 
-This allows the product team to setup authentication to the Jenkins via Github OAuth.
-
-An app needs to be created for each environment (and therefore URL) the team created.
-
-Use the following settings to setup your app. Any fields or options that are not mentioned here can be left blank or with their default value.
-
-The [URL] will follow the pattern `https://[environment].[team_name].build.gds-reliability.engineering`.
-
-* GitHub App name:  `re-build-auth-[team name]-[environment]` , e.g. `re-build-auth-app-eidas-dev`. You may have to deviate from this format if it exceeds 34 characters.
-
-* Description:  Build system for [URL]
-
-* Homepage URL:  [URL]
-
-* User authorization callback URL:  [URL]/securityRealm/finishLogin
-
-* Webhook URL: [URL]
-
-* Permissions > Organization members: `Access: Read-only`
-
-## Provide the app credentials to the product team
-
-For each app you created, provide the `id` and `secret` to the product team, so that
-they can complete the provisioning of their Jenkins.

--- a/terraform/jenkins/terraform.tfvars.example
+++ b/terraform/jenkins/terraform.tfvars.example
@@ -11,12 +11,6 @@ allowed_ips = [
 # The team_name you defined earlier
 team_name = "your-team-name"
 
-# The client ID you were given when the GitHub OAuth app was created
-github_client_id = "aabbccddee"
-
-# The client secret you were given when the GitHub OAuth app was created
-github_client_secret = "abcdefghijklmnopqrstuvwxzy0123456789"
-
 # A list of GitHub teams you want to grant access to your Jenkins
 github_organisations = [
   "team1",


### PR DESCRIPTION
This has been testing by standing up and environment and it seems to work.

This commit does two things - that is not ideal but they are both simple things:
- move the documentation on how to set up the Github OAuth app from the RE documentation
section to the main installation guide. It also correct the fact that a 'OAuth app' needs
to be created, rather than a 'Github app'.
- the Github OAuth credentials are not stored in the configuration file anymore, but passed
as an argument to Terraform