### PR TITLE
Develop worker docker image

### DIFF
--- a/docker/files/groovy/add-sample-agent-docker-image.groovy
+++ b/docker/files/groovy/add-sample-agent-docker-image.groovy
@@ -1,0 +1,98 @@
+import com.nirima.jenkins.plugins.docker.DockerCloud
+import com.nirima.jenkins.plugins.docker.DockerTemplate
+import com.nirima.jenkins.plugins.docker.DockerTemplateBase
+import com.nirima.jenkins.plugins.docker.launcher.AttachedDockerComputerLauncher
+import io.jenkins.docker.connector.DockerComputerAttachConnector
+import jenkins.model.Jenkins
+ 
+// parameters
+def dockerTemplateBaseParameters = [
+  bindAllPorts:       false,
+  bindPorts:          '',
+  cpuShares:          null,
+  dnsString:          '',
+  dockerCommand:      '',
+  environmentsString: '',
+  extraHostsString:   '',
+  hostname:           '',
+  image:              'danieleocchipinti/jenkins-agent-java8-with-maven:latest', // custom image
+  macAddress:         '',
+  memoryLimit:        null,
+  memorySwap:         null,
+  network:            '',
+  privileged:         false,
+  pullCredentialsId:  '',
+  tty:                true,
+  volumesFromString:  '',
+  volumesString:      ''
+]
+ 
+def DockerTemplateParameters = [
+  instanceCapStr: '4',
+  labelString:    'docker-jnlp-java-agent', // custom labelString
+  remoteFs:       ''
+]
+ 
+def dockerCloudParameters = [
+  connectTimeout:   3,
+  containerCapStr:  '4',
+  credentialsId:    '',
+  dockerHostname:   '',
+  name:             'docker-worker-2-java', // custom name
+  readTimeout:      60,
+  serverUrl:        'tcp://worker:2375', // custom serverUrl
+  version:          ''
+]
+ 
+// https://github.com/jenkinsci/docker-plugin/blob/docker-plugin-1.1.2/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+DockerTemplateBase dockerTemplateBase = new DockerTemplateBase(
+  dockerTemplateBaseParameters.image,
+  dockerTemplateBaseParameters.pullCredentialsId,
+  dockerTemplateBaseParameters.dnsString,
+  dockerTemplateBaseParameters.network,
+  dockerTemplateBaseParameters.dockerCommand,
+  dockerTemplateBaseParameters.volumesString,
+  dockerTemplateBaseParameters.volumesFromString,
+  dockerTemplateBaseParameters.environmentsString,
+  dockerTemplateBaseParameters.hostname,
+  dockerTemplateBaseParameters.memoryLimit,
+  dockerTemplateBaseParameters.memorySwap,
+  dockerTemplateBaseParameters.cpuShares,
+  dockerTemplateBaseParameters.bindPorts,
+  dockerTemplateBaseParameters.bindAllPorts,
+  dockerTemplateBaseParameters.privileged,
+  dockerTemplateBaseParameters.tty,
+  dockerTemplateBaseParameters.macAddress,
+  dockerTemplateBaseParameters.extraHostsString
+)
+ 
+// https://github.com/jenkinsci/docker-plugin/blob/docker-plugin-1.1.2/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+DockerTemplate dockerTemplate = new DockerTemplate(
+  dockerTemplateBase,
+  new DockerComputerAttachConnector(),
+  DockerTemplateParameters.labelString,
+  DockerTemplateParameters.remoteFs,
+  DockerTemplateParameters.instanceCapStr
+)
+ 
+// https://github.com/jenkinsci/docker-plugin/blob/docker-plugin-1.1.2/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+DockerCloud dockerCloud = new DockerCloud(
+  dockerCloudParameters.name,
+  [dockerTemplate],
+  dockerCloudParameters.serverUrl,
+  dockerCloudParameters.containerCapStr,
+  dockerCloudParameters.connectTimeout,
+  dockerCloudParameters.readTimeout,
+  dockerCloudParameters.credentialsId,
+  dockerCloudParameters.version,
+  dockerCloudParameters.dockerHostname
+)
+ 
+// get Jenkins instance
+Jenkins jenkins = Jenkins.getInstance()
+ 
+// add cloud configuration to Jenkins
+jenkins.clouds.add(dockerCloud)
+ 
+// save current Jenkins state to disk
+jenkins.save()

--- a/docs/docs_for_team/README.md
+++ b/docs/docs_for_team/README.md
@@ -16,23 +16,17 @@ agent {
 }
 ```
 
-`docker-jnlp-java-agent` is an the Docker  image you define in Jenkins, via
-'Manage Jenkins' -> 'Configure system' -> 'Cloud' -> 'Add a new cloud'.
-The settings are:
+Your docker image can be defined using the [template file](https://github.com/alphagov/re-build-systems/blob/master/docker/files/groovy/add-sample-agent-docker-image.groovy).
+Please make a copy of that file and edit it to your own specification. There are four variables that need adjusting;
 
-* Name: docker-worker-2-java
-* Docker Host URI: tcp://worker:2375
-* Label: docker-jnlp-java-agent
-* Docker image: [builder-docker-image-url]
-* Remote filesystem root: /home/jenkins
-* Connect method: Attach Docker container
+* image - The hash or tagged name of the image that you wish docker to run
+* labelString - Must match the agent:label in the Jenkinsfile of your app
+* name - Name of this Docker Cloud
+* serverUrl - URI to the Docker Host you are using.
 
-That can also be done via a Groovy script.
+These are all labelled 'custom' within the template file.
 
-`builder-docker-image-url` is the URL of the Docker image which is going to build the code (for example, it may be hosted on Dockerhub).
-
-The way you build the image is by inheriting from the `jenkins/jnlp-slave` base image and install
-your development tools on top of it.
+For extra guidance on using Jenkins' Docker plugin visit their [help page](https://wiki.jenkins.io/display/JENKINS/Docker+Plugin)
 
 This is an example of a builder Docker image for Maven (bear in mind that the Jenkins slave image installs Java8):
 


### PR DESCRIPTION
This allows users to copy a template file for loading a docker image to Jenkins. This means that Docker images can be more easily loaded and configured using code rather than through the use of the Jenkins UI. 

The developer docs have been changed to reflect this. 

https://trello.com/c/48vnGYCe/148-test-whether-an-agent-image-can-be-created-by-using-the-build-toolchain-as-a-base