### PR TITLE
Add known bugs section to README

### DIFF
--- a/docs/docs_for_team/README.md
+++ b/docs/docs_for_team/README.md
@@ -73,6 +73,10 @@ From Jenkins, 'New item' -> 'Pipeline'. Then, the settings are as follows:
 * SCM: Git
 * Pipeline Repository URL: [git-repo-url]
 
+## Known bugs
+
+As it stands Docker configuration is loaded from a git branch specified in the [cloud init yaml file]. If you make changes to your Docker config, including adding an image as in the instructions above, you must make sure that your changes are pushed to a branch on git. Before running a `terraform apply` you will need to update the [Jenkins variables file] with the name of your working branch rather than master. In this way the name of your working branch need never be committed to git. We are planning on automating this process.
+
 ## Decommissioning of the Jenkins
 
 There are 4 steps to decommission the Jenkins platform for one of your environments:
@@ -179,5 +183,7 @@ Go to [Github developer settings] > `OAuth Apps` > Select the app > `Delete appl
 [the main README of the repo]: https://github.com/alphagov/re-build-systems-dns
 [example of a project]: https://github.com/alphagov/re-build-systems-sample-java-app/tree/jenkinsfile-supported-by-re-build-mvp
 [template file]: https://github.com/alphagov/re-build-systems/blob/master/docker/files/groovy/add-sample-agent-docker-image.groovy
+[cloud init yaml file]: (terraform/jenkins/cloud-init/server-asg-xenial-16.04-amd64-server.yaml)
+[Jenkins variables file]: (terraform/jenkins/variables.tf)
 [help page]: https://wiki.jenkins.io/display/JENKINS/Docker+Plugin
 [Github developer settings]: https://github.com/settings/developers


### PR DESCRIPTION
Whilst making changes to the way in which Docker images are loaded we noticed that things were not working in the way we expected. Basically code was being loaded into terraform from the developers local git master branch. This means that old code could be used to initialise Jenkins and changes to the development branch would not. 

There isn't an easy fix to this at the moment so a trello card will be made to address the issue. For the time being teams need to be aware of this so that they can test changes in development environments.