### PR TITLE
Fix lifecycle for TLS Cert

### DIFF
--- a/terraform/jenkins/tls.tf
+++ b/terraform/jenkins/tls.tf
@@ -8,6 +8,10 @@ resource "aws_acm_certificate" "tls_certificate" {
   domain_name               = "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
   validation_method         = "DNS"
   subject_alternative_names = "${local.san_domains}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "dns_validation" {


### PR DESCRIPTION
When running a terraform destroy, it will error on the destruction of the TLS cert being in use.

Following the recommendations and documention from a slightly newer version of terraform, they recommend setting create before destroy.

Further details available [here](https://github.com/terraform-providers/terraform-provider-aws/issues/4537) and [here](https://github.com/terraform-providers/terraform-provider-aws/pull/4925/files)

Solo: @smford