### PR TITLE
Enable ssh to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,25 +245,13 @@ For this step, you will need to choose which environment you want to set up Jenk
 
 To SSH into the master instance run:
 ```
-ssh -i [path-to-the-private-ssh-key-you-generated] ubuntu@[master_ec2_public_dns]
-```
-
-You can get `master_ec2_public_dns` (the public DNS of the master EC2 instance) via the AWS console or `awscli` - just be aware that may change.
-
-To get the DNS name of the Jenkins master using the AWS cli, you can use the following:
-
-```
-# Jenkins master
-aws ec2 describe-instances --region=eu-west-1 --filters "Name=tag:Type,Values=Jenkins-master" | grep PublicDnsName | head -1 | cut -d':' -f2 | sed 's/[ ",]//g'
-# Jenkins worker
-aws ec2 describe-instances --region=eu-west-1 --filters "Name=tag:Type,Values=Jenkins-worker" | grep PublicDnsName | head -1 | cut -d':' -f2 | sed 's/[ ",]//g'
+ssh -i [path-to-the-private-ssh-key-you-generated] ubuntu@[jenkins2.my-env.my-team.build.gds-reliability.engineering]
 ```
 
 To SSH into the agents instance you need to use the master node as a proxy, like so:
 ```
-ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@[master_ec2_public_dns]' ubuntu@[agent_ec2_public_dns]
+ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@jenkins2.my-env.my-team.build.gds-reliability.engineering' ubuntu@worker
 ```
-Again, you can get `master_ec2_public_dns` and `agent_ec2_public_dns` via the AWS console or `awscli`.
 
 Once logged in with the `ubuntu` user, you can switch to the root user by running `sudo su -`.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ ssh -i [path-to-the-private-ssh-key-you-generated] ubuntu@[jenkins2.my-env.my-te
 
 To SSH into the agents instance you need to use the master node as a proxy, like so:
 ```
-ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@jenkins2.my-env.my-team.build.gds-reliability.engineering' ubuntu@worker
+ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@[jenkins2.my-env.my-team.build.gds-reliability.engineering]' ubuntu@worker
 ```
 
 Once logged in with the `ubuntu` user, you can switch to the root user by running `sudo su -`.

--- a/terraform/jenkins/asg.tf
+++ b/terraform/jenkins/asg.tf
@@ -103,6 +103,13 @@ resource "aws_elb" "elb_jenkins2_server" {
     ssl_certificate_id = "${aws_acm_certificate.tls_certificate.arn}"
   }
 
+  listener {
+    instance_port     = 22
+    instance_protocol = "tcp"
+    lb_port           = 22
+    lb_protocol       = "tcp"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 10

--- a/terraform/jenkins/sg-asg.tf
+++ b/terraform/jenkins/sg-asg.tf
@@ -8,10 +8,10 @@ module "jenkins2_sg_asg_server_internal" {
 
   ingress_with_cidr_blocks = [
     {
-      from_port   = 50000
-      to_port     = 50000
+      from_port   = 22
+      to_port     = 22
       protocol    = "tcp"
-      description = "Docker hosts talking back to server - JNLP"
+      description = "ELB talking to server - SSH"
       cidr_blocks = "${var.public_subnet}"
     },
     {
@@ -19,6 +19,13 @@ module "jenkins2_sg_asg_server_internal" {
       to_port     = 80
       protocol    = "tcp"
       description = "Docker hosts talking back to server - HTTP"
+      cidr_blocks = "${var.public_subnet}"
+    },
+    {
+      from_port   = 50000
+      to_port     = 50000
+      protocol    = "tcp"
+      description = "Docker hosts talking back to server - JNLP"
       cidr_blocks = "${var.public_subnet}"
     },
   ]


### PR DESCRIPTION
This enables ssh'ing to the master using the nice ELB hostname - similar to: jenkins2.my-env.my-team.build.gds-reliability.engineering

Once ssh'd to the master, you can proxy to the workers.

Solo: @smford 