### PR TITLE
Remove jenkins2 aka server_name from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You need to provision the DNS infrastructure only once, and have the Reliability
 Then, you can provision the main Jenkins infrastructure anytime you need to create a new environment.
 
 For each environment you create the associate URL will be in this form:
-`https://jenkins2.[environment_name].[team_name].build.gds-reliability.engineering`
+`https://[environment_name].[team_name].build.gds-reliability.engineering`
 
 ## Provision the DNS infrastructure
 
@@ -148,7 +148,7 @@ For this step, you will need to choose which environment you want to set up Jenk
 
     Go to the [Register a new OAuth application] page and use the following settings to setup your app.
 
-    The [URL] will follow the pattern `https://jenkins2.[environment-name].[team-name].build.gds-reliability.engineering`.
+    The [URL] will follow the pattern `https://[environment-name].[team-name].build.gds-reliability.engineering`.
 
     * Application name:  `re-build-auth-[team name]-[environment name]` , e.g. `re-build-auth-app-eidas-dev`. You may have to deviate from this format if it exceeds 34 characters.
 
@@ -245,12 +245,12 @@ For this step, you will need to choose which environment you want to set up Jenk
 
 To SSH into the master instance run:
 ```
-ssh -i [path-to-the-private-ssh-key-you-generated] ubuntu@[jenkins2.my-env.my-team.build.gds-reliability.engineering]
+ssh -i [path-to-the-private-ssh-key-you-generated] ubuntu@[my-env.my-team.build.gds-reliability.engineering]
 ```
 
 To SSH into the agents instance you need to use the master node as a proxy, like so:
 ```
-ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@[jenkins2.my-env.my-team.build.gds-reliability.engineering]' ubuntu@worker
+ssh -i [path-to-the-private-ssh-key-you-generated] -o ProxyCommand='ssh -W %h:%p ubuntu@[my-env.my-team.build.gds-reliability.engineering]' ubuntu@worker
 ```
 
 Once logged in with the `ubuntu` user, you can switch to the root user by running `sudo su -`.

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -64,7 +64,7 @@ This is an example of a configuration to provision both DNS and Jenkins instance
 
 	Go to the [Register a new OAuth application](https://github.com/settings/applications/new) and use the following settings to setup your app.
 
-	The [URL] will follow the pattern `https://[server_name].[environment].[team_name].[hostname_suffix]`.  For example `https://jenkins2.dev.my-team.example.com`
+	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.example.com`
 
 	* Application name:  `jenkins-[environment]-[team_name]` , e.g. `jenkins-dev-my-team`.
 
@@ -72,7 +72,7 @@ This is an example of a configuration to provision both DNS and Jenkins instance
 
 	* Application description:  Build system for [URL]
 
-	* Authorization callback URL:  https://[server_name].[environment].[team_name].[hostname_suffix]/securityRealm/finishLogin
+	* Authorization callback URL:  https://[environment].[team_name].[hostname_suffix]/securityRealm/finishLogin
 
 	Then, click the 'Register application' button.
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -26,7 +26,7 @@ You need to provision the DNS infrastructure only once, and have the Reliability
 Then, you can provision the main Jenkins infrastructure anytime you need to create a new environment.
 
 For each environment you create the associate URL will be in this form:
-`https://[server_name].[environment].[team_name].build.gds-reliability.engineering`
+`https://[environment].[team_name].build.gds-reliability.engineering`
 
 ## Provision the DNS infrastructure
 
@@ -134,7 +134,7 @@ For this step, you will need to choose which environment you want to set up Jenk
 
 	Go to the [Register a new OAuth application](https://github.com/settings/applications/new) and use the following settings to setup your app.
 
-	The [URL] will follow the pattern `https://[server_name].[environment].[team_name].[hostname_suffix]`.  For example `https://jenkins2.dev.my-team.build.gds-reliability.engineering`
+	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
 
 	* Application name:  `jenkins-[environment]-[team_name]` , e.g. `jenkins-dev-my-team`.
 
@@ -142,7 +142,7 @@ For this step, you will need to choose which environment you want to set up Jenk
 
 	* Application description:  `Build system for [URL]`
 
-	* Authorization callback URL:  `https://[server_name].[environment].[team_name].[hostname_suffix]/securityRealm/finishLogin`
+	* Authorization callback URL:  `https://[environment].[team_name].[hostname_suffix]/securityRealm/finishLogin`
 
 	Then, click the 'Register application' button.
 


### PR DESCRIPTION
This matches with the PR [here](https://github.com/alphagov/terraform-aws-re-build-jenkins/pull/5)

Solo: @smford