### PR TITLE
Set Jenkins url via groovy to remove jenkins warning

### DIFF
--- a/docker/files/groovy/configure-jenkins-url.groovy
+++ b/docker/files/groovy/configure-jenkins-url.groovy
@@ -1,0 +1,5 @@
+import jenkins.model.JenkinsLocationConfiguration
+jlc = JenkinsLocationConfiguration.get()
+jlc.setUrl(env['JENKINS_URL']) 
+println(jlc.getUrl())
+jlc.save()


### PR DESCRIPTION
This sets the jenkins url which removes a warning.  It pairs with this [PR](https://github.com/alphagov/terraform-aws-re-build-jenkins/pull/7)

Solo: @smford