### PR TITLE
Removing ability to overide jenkins version

### DIFF
--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -39,7 +39,6 @@ This is an example of a configuration to provision both DNS and Jenkins instance
 	| `gitrepo` | string | | https://github.com/alphagov/re-build-systems.git | Git repo that hosts Dockerfile |
 	| `gitrepo_branch` | string | | master | Branch of git repo that hosts Dockerfile |
 	| `hostname_suffix` | string | **yes** | none | Main domain name for new Jenkins instances, eg. example.com |
-	| `jenkins_version` | string | | latest | Version of jenkins to install |
 	| `server_instance_type` | string | | t2.small | This defines the default master server EC2 instance type |
 	| `server_name` | string | | jenkins2 | Hostname of the jenkins2 master |
 	| `server_root_volume_size` | string | | 50 | Size of the Jenkins Server root volume (GB) |

--- a/examples/complete_deployment_of_dns_and_jenkins/main.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/main.tf
@@ -38,8 +38,6 @@ module "jenkins" {
 
   docker_version = "${var.docker_version}"
 
-  jenkins_version = "${var.jenkins_version}"
-
   # Ubuntu Version
   ubuntu_release = "${var.ubuntu_release}"
 

--- a/examples/complete_deployment_of_dns_and_jenkins/terraform.tfvars.example
+++ b/examples/complete_deployment_of_dns_and_jenkins/terraform.tfvars.example
@@ -30,8 +30,6 @@ gitrepo_branch = "master"
 
 hostname_suffix = "build.gds-reliability.engineering"
 
-jenkins_version = "latest"
-
 server_instance_type = "t2.small"
 
 server_name = "jenkins"

--- a/examples/complete_deployment_of_dns_and_jenkins/variables.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/variables.tf
@@ -69,12 +69,6 @@ variable "hostname_suffix" {
   type        = "string"
 }
 
-variable "jenkins_version" {
-  description = "Verson of jenkins to install"
-  type        = "string"
-  default     = "latest"
-}
-
 variable "server_instance_type" {
   description = "This defines the default master server EC2 instance type"
   type        = "string"

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -201,7 +201,6 @@ For this step, you will need to choose which environment you want to set up Jenk
 	| `gitrepo` | string | | https://github.com/alphagov/re-build-systems.git | Git repo that hosts Dockerfile |
 	| `gitrepo_branch` | string | | master | Branch of git repo that hosts Dockerfile |
 	| `hostname_suffix` | string | **yes** | none | Main domain name for new Jenkins instances, eg. example.com |
-	| `jenkins_version` | string | | latest | Version of jenkins to install |
 	| `server_instance_type` | string | | t2.small | This defines the default master server EC2 instance type |
 	| `server_name` | string | | jenkins2 | Hostname of the jenkins2 master |
 	| `server_root_volume_size` | string | | 50 | Size of the Jenkins Server root volume (GB) |

--- a/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
@@ -29,8 +29,6 @@ module "jenkins" {
 
   docker_version = "${var.docker_version}"
 
-  jenkins_version = "${var.jenkins_version}"
-
   # Ubuntu Version
   ubuntu_release = "${var.ubuntu_release}"
 

--- a/examples/gds_specific_dns_and_jenkins/jenkins/terraform.tfvars.example
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/terraform.tfvars.example
@@ -30,8 +30,6 @@ gitrepo_branch = "master"
 
 hostname_suffix = "build.gds-reliability.engineering"
 
-jenkins_version = "latest"
-
 server_instance_type = "t2.small"
 
 server_name = "jenkins"

--- a/examples/gds_specific_dns_and_jenkins/jenkins/variables.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/variables.tf
@@ -69,12 +69,6 @@ variable "hostname_suffix" {
   type        = "string"
 }
 
-variable "jenkins_version" {
-  description = "Verson of jenkins to install"
-  type        = "string"
-  default     = "latest"
-}
-
 variable "server_instance_type" {
   description = "This defines the default master server EC2 instance type"
   type        = "string"


### PR DESCRIPTION
We want to control and pin the jenkins version, this PR updates documentation and examples showing how to change the jenkins_version.

This PR goes with [this PR](https://github.com/alphagov/terraform-aws-re-build-jenkins/pull/8)

Solo: @smford