### PR TITLE
Update examples to use first module release

### DIFF
--- a/examples/complete_deployment_of_dns_and_jenkins/main.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/main.tf
@@ -1,16 +1,12 @@
 module "dns" {
-  # The next line needs to be a link to where the DNS module has been downloaded.
-  source  = "./dns_module"
-  version = "1.0.0"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
 
   team_name       = "${var.team_name}"
   hostname_suffix = "${var.hostname_suffix}"
 }
 
 module "jenkins" {
-  # The next line needs to be a link to where the Jenkins module has been downloaded.
-  source  = "./jenkins_module"
-  version = "1.0.0"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.1"
 
   # Environment configuration.
   allowed_ips = "${var.allowed_ips}"

--- a/examples/gds_specific_dns_and_jenkins/dns/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/dns/main.tf
@@ -1,7 +1,5 @@
 module "dns" {
-  # The next line needs to be a link to where the DNS module has been downloaded.
-  source  = "./dns_module"
-  version = "1.0.0"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
 
   team_name       = "${var.team_name}"
   hostname_suffix = "${var.hostname_suffix}"

--- a/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
@@ -1,7 +1,5 @@
 module "jenkins" {
-  # The next line needs to be a link to where the Jenkins module has been downloaded.
-  source  = "./jenkins_module"
-  version = "1.0.0"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.1"
 
   # Environment configuration.
   allowed_ips = "${var.allowed_ips}"


### PR DESCRIPTION
This sets the examples to use release 0.0.1 of both the jenkins and dns module, and means that a local symlink to the repo is no longer required.

Solo: @smford