### PR TITLE
By removing specific docker version it will always install the latest.

### DIFF
--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -30,7 +30,6 @@ This is an example of a configuration to provision both DNS and Jenkins instance
 	| `aws_az` | string | | the first AZ in a region | Single availability zone to place master and worker instances in, eg. eu-west-1a |
 	| `aws_profile` | string | | default aws profile in ~/.aws/credentials | AWS Profile (credentials) to use |
 	| `aws_region` | string | | default aws region | AWS Region to use, eg. eu-west-1 |
-	| `docker_version` | string | **yes** | none | The version of docker to install |
 	| `environment` | string | **yes** | none | Environment name (e.g. production, test, ci). This is used to construct the DNS name for your Jenkins instances |
 	| `github_admin_users` | list | | none | List of Github admin users (github user name) |
 	| `github_client_id` | string | | none | Your Github Auth client ID |

--- a/examples/complete_deployment_of_dns_and_jenkins/main.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/main.tf
@@ -36,8 +36,6 @@ module "jenkins" {
   hostname_suffix      = "${var.hostname_suffix}"
   route53_team_zone_id = "${module.dns.team_zone_id}"
 
-  docker_version = "${var.docker_version}"
-
   # Ubuntu Version
   ubuntu_release = "${var.ubuntu_release}"
 

--- a/examples/complete_deployment_of_dns_and_jenkins/terraform.tfvars.example
+++ b/examples/complete_deployment_of_dns_and_jenkins/terraform.tfvars.example
@@ -9,8 +9,6 @@ aws_profile = "my-aws-credentials-profile"
 
 aws_region = "eu-west-1"
 
-docker_version = "18.03.1~ce-0~ubuntu"
-
 environment = "development"
 
 github_admin_users = [

--- a/examples/complete_deployment_of_dns_and_jenkins/variables.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/variables.tf
@@ -19,11 +19,6 @@ variable "aws_region" {
   type        = "string"
 }
 
-variable "docker_version" {
-  description = "The version of docker to install"
-  type        = "string"
-}
-
 variable "environment" {
   description = "Environment name (e.g. production, test, ci). This is used to construct the DNS name for your Jenkins instances"
   type        = "string"

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -192,7 +192,6 @@ For this step, you will need to choose which environment you want to set up Jenk
 	| `aws_az` | string | | the first AZ in a region | Single availability zone to place master and worker instances in, eg. eu-west-1a |
 	| `aws_profile` | string | | default aws profile in ~/.aws/credentials | AWS Profile (credentials) to use |
 	| `aws_region` | string | | default aws region | AWS Region to use, eg. eu-west-1 |
-	| `docker_version` | string | **yes** | none | The version of docker to install |
 	| `environment` | string | **yes** | none | Environment name (e.g. production, test, ci). This is used to construct the DNS name for your Jenkins instances |
 	| `github_admin_users` | list | | none | List of Github admin users (github user name) |
 	| `github_client_id` | string | | none | Your Github Auth client ID |

--- a/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
@@ -27,8 +27,6 @@ module "jenkins" {
   hostname_suffix      = "${var.hostname_suffix}"
   route53_team_zone_id = "${data.terraform_remote_state.team_dns.team_zone_id}"
 
-  docker_version = "${var.docker_version}"
-
   # Ubuntu Version
   ubuntu_release = "${var.ubuntu_release}"
 

--- a/examples/gds_specific_dns_and_jenkins/jenkins/terraform.tfvars.example
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/terraform.tfvars.example
@@ -9,8 +9,6 @@ aws_profile = "my-aws-credentials-profile"
 
 aws_region = "eu-west-1"
 
-docker_version = "18.03.1~ce-0~ubuntu"
-
 environment = "development"
 
 github_admin_users = [

--- a/examples/gds_specific_dns_and_jenkins/jenkins/variables.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/variables.tf
@@ -19,11 +19,6 @@ variable "aws_region" {
   type        = "string"
 }
 
-variable "docker_version" {
-  description = "The version of docker to install"
-  type        = "string"
-}
-
 variable "environment" {
   description = "Environment name (e.g. production, test, ci). This is used to construct the DNS name for your Jenkins instances"
   type        = "string"


### PR DESCRIPTION
This aligns with the upgrade process vision, and prevents legacy versions
being installed.

This pairs with this [PR](https://github.com/alphagov/terraform-aws-re-build-jenkins/pull/10)

Solo: @smford