### PR TITLE
Remove module version pinning from examples

### DIFF
--- a/examples/complete_deployment_of_dns_and_jenkins/main.tf
+++ b/examples/complete_deployment_of_dns_and_jenkins/main.tf
@@ -1,12 +1,18 @@
 module "dns" {
-  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git"
+
+  # If a specific release is needed rather than "latest", the below syntax can be used.
+  # source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
 
   team_name       = "${var.team_name}"
   hostname_suffix = "${var.hostname_suffix}"
 }
 
 module "jenkins" {
-  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.1"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git"
+
+  # If a specific release is needed rather than "latest", the below syntax can be used.
+  # source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.2"
 
   # Environment configuration.
   allowed_ips = "${var.allowed_ips}"
@@ -14,30 +20,24 @@ module "jenkins" {
   environment = "${var.environment}"
   region      = "${var.aws_region}"
   team_name   = "${var.team_name}"
-
   # Git repo
   gitrepo        = "${var.gitrepo}"
   gitrepo_branch = "${var.gitrepo_branch}"
-
   # Github auth configuration
   github_admin_users   = ["${join(",", var.github_admin_users)}"]
   github_client_id     = "${var.github_client_id}"
   github_client_secret = "${var.github_client_secret}"
   github_organisations = ["${join(",", var.github_organisations)}"]
-
   # Public key
   ssh_public_key_file = "${var.ssh_public_key_file}"
-
   # DNS configuration
   hostname_suffix      = "${var.hostname_suffix}"
   route53_team_zone_id = "${module.dns.team_zone_id}"
-
   # Server Configuration
   server_instance_type    = "${var.server_instance_type}"
   server_name             = "${var.server_name}"
   server_user_data        = "${var.server_user_data}"
   server_root_volume_size = "${var.server_root_volume_size}"
-
   # Worker Configuration
   worker_instance_type    = "${var.worker_instance_type}"
   worker_name             = "${var.worker_name}"

--- a/examples/gds_specific_dns_and_jenkins/dns/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/dns/main.tf
@@ -1,5 +1,8 @@
 module "dns" {
-  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git"
+
+  # If a specific release is needed rather than "latest", the below syntax can be used.
+  # source = "git::https://github.com/alphagov/terraform-aws-re-build-dns.git?ref=0.0.1"
 
   team_name       = "${var.team_name}"
   hostname_suffix = "${var.hostname_suffix}"

--- a/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
+++ b/examples/gds_specific_dns_and_jenkins/jenkins/main.tf
@@ -1,5 +1,8 @@
 module "jenkins" {
-  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.1"
+  source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git"
+
+  # If a specific release is needed rather than "latest", the below syntax can be used.
+  # source = "git::https://github.com/alphagov/terraform-aws-re-build-jenkins.git?ref=0.0.2"
 
   # Environment configuration.
   allowed_ips = "${var.allowed_ips}"


### PR DESCRIPTION
The examples had the module versions pinned to v0.0.1, this causes maintenance overhead and confusion by the end user.  Instead I have removed module version pinning (to releases) meaning they use the latest (master branch) and have added inline documentation detailing how one may choose to pin if needed.

Solo: @smford