### PR TITLE
Fixes in documentation from CS UR Feedback

### DIFF
--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -26,6 +26,19 @@ Before you start you'll need:
 	aws_secret_access_key = [your aws secret here]
 	```
 
+1. Set AWS environment variables
+
+    **Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
+
+    If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
+
+    ```
+    export AWS_ACCESS_KEY_ID="[aws key]"
+    export AWS_SECRET_ACCESS_KEY="[aws secret]"
+    export AWS_DEFAULT_REGION="eu-west-1"
+    ```
+
+
 1. Clone the re-build-systems repo
 
   ```
@@ -61,16 +74,6 @@ Before you start you'll need:
 	| `worker_instance_type` | string | | t2.medium | This defines the default worker server EC2 instance type |
 	| `worker_name` | string | | worker | Name of the Jenkins2 worker |
 	| `worker_root_volume_size` | string | | 50 | Size of the Jenkins worker root volume (GB) |
-
-1. Set AWS environment variables
-
-    If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
-
-    ```
-    export AWS_ACCESS_KEY_ID="[aws key]"
-    export AWS_SECRET_ACCESS_KEY="[aws secret]"
-    export AWS_DEFAULT_REGION="eu-west-1"
-    ```
 
 1. Create a GitHub OAuth app to allow you to setup authentication to the Jenkins through GitHub.
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -1,5 +1,7 @@
 # Example configuration
 
+This working example that demonstrates how you can use our modules to deploy jenkins using terraform.  By working through the example it will result in you having a working deployment of jenkins using our terraform modules.
+
 ## Prerequisites
 
 Before you start you'll need:

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -81,10 +81,12 @@ Before you start you'll need:
 
 	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
 
-	* Application name:  jenkins-[environment]-[team-name]  e.g. jenkins-dev-my-team
-	* Homepage URL:  [URL]
-	* Application description:  Build system for [URL]
-	* Authorization callback URL:  [URL]/securityRealm/finishLogin
+	```
+	Application name: jenkins-[environment]-[team-name] e.g. jenkins-dev-my-team
+	Homepage URL: [URL]
+	Application description: Build system for [URL]
+	Authorization callback URL: [URL]/securityRealm/finishLogin
+	```
 
 	Then, click the 'Register application' button.
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -30,7 +30,7 @@ Before you start you'll need:
 
 	**Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
 
-	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
+	**Note:** If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"
@@ -90,12 +90,14 @@ Before you start you'll need:
 
 	Export the credentials as they appear on the screen:
 
-	If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
+	**Note:** If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
 
 	```
 	export JENKINS_GITHUB_OAUTH_ID="[client-id]"
 	export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
 	```
+
+	The github credentials are exported so that no secrets are stored on the local machine.
 
 1. Set Jenkins related environment variables
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -150,8 +150,8 @@ Before you start you'll need:
 
 ## Next Steps
 
-  * The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to gain control
-  * ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
+* The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to restrict access
+* ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
 
 ## Contributing
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -24,7 +24,7 @@ Before you start you'll need:
 
 1. Change into the `examples/complete_deployment_of_dns_and_jenkins` directory
 
-1. Rename the `terraform.tfvars.example` file as `terraform.tfvars`.
+1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 1. Edit the `terraform.tfvars` file to reflect the following configuration:
 
@@ -54,13 +54,13 @@ Before you start you'll need:
 
 1. Set AWS environment variables
 
+    If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
+
     ```
     export AWS_ACCESS_KEY_ID="[aws key]"
     export AWS_SECRET_ACCESS_KEY="[aws secret]"
     export AWS_DEFAULT_REGION="eu-west-1"
     ```
-
-	If you're using bash, add a space at the start of export `AWS_ACCESS_KEY_ID` and export `AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 1. Create a GitHub OAuth app to allow you to setup authentication to the Jenkins through GitHub.
 
@@ -80,12 +80,12 @@ Before you start you'll need:
 
     Export the credentials as they appear on the screen:
 
+    If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
+
     ```
     export JENKINS_GITHUB_OAUTH_ID="[client-id]"
     export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
     ```
-
-    If you're using bash, add a space at the start of export `AWS_ACCESS_KEY_ID` and export `AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 1. Set Jenkins related environment variables
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -2,6 +2,8 @@
 
 This working example that demonstrates how you can use our modules to deploy jenkins using terraform.  By working through the example it will result in you having a working deployment of jenkins using our terraform modules.
 
+To work through this example you will need to clone this repo.
+
 ## Prerequisites
 
 Before you start you'll need:
@@ -23,6 +25,12 @@ Before you start you'll need:
 	aws_access_key_id = [your aws key here]
 	aws_secret_access_key = [your aws secret here]
 	```
+
+1. Clone the re-build-systems repo
+
+  ```
+  git clone https://github.com/alphagov/re-build-systems.git
+  ```
 
 1. Change into the `examples/complete_deployment_of_dns_and_jenkins` directory
 

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -97,7 +97,7 @@ Before you start you'll need:
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
     ```
-    create-s3-state-bucket \
+    ./create-s3-state-bucket \
       -t $JENKINS_TEAM_NAME \
       -e $JENKINS_ENV_NAME \
       -p [my-aws-profile]

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -146,6 +146,11 @@ Before you start you'll need:
 	  my-plan.txt
 	```
 
+## Next Steps
+
+  * The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to gain control
+  * ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
+
 ## Contributing
 
 Refer to our [Contributing guide].

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -143,8 +143,8 @@ Refer to our [Contributing guide].
 [MIT License]
 
 [AWS Command Line Interface (CLI)]: https://aws.amazon.com/cli/
-[Contributing guide]: CONTRIBUTING.md
-[MIT License]: LICENSE
+[Contributing guide]: https://github.com/alphagov/re-build-systems/blob/master/CONTRIBUTING.md
+[MIT License]: https://github.com/alphagov/re-build-systems/blob/master/LICENCE
 [Register a new OAuth application]: https://github.com/settings/applications/new
 [S3 bucket]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
 [Terraform]: https://www.terraform.io/intro/index.html

--- a/examples/complete_deployment_of_dns_and_jenkins/README.md
+++ b/examples/complete_deployment_of_dns_and_jenkins/README.md
@@ -28,22 +28,22 @@ Before you start you'll need:
 
 1. Set AWS environment variables
 
-    **Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
+	**Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
 
-    If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
+	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
-    ```
-    export AWS_ACCESS_KEY_ID="[aws key]"
-    export AWS_SECRET_ACCESS_KEY="[aws secret]"
-    export AWS_DEFAULT_REGION="eu-west-1"
-    ```
+	```
+	export AWS_ACCESS_KEY_ID="[aws key]"
+	export AWS_SECRET_ACCESS_KEY="[aws secret]"
+	export AWS_DEFAULT_REGION="eu-west-1"
+	```
 
 
 1. Clone the re-build-systems repo
 
-  ```
-  git clone https://github.com/alphagov/re-build-systems.git
-  ```
+	```
+	git clone https://github.com/alphagov/re-build-systems.git
+	```
 
 1. Change into the `examples/complete_deployment_of_dns_and_jenkins` directory
 
@@ -77,75 +77,72 @@ Before you start you'll need:
 
 1. Create a GitHub OAuth app to allow you to setup authentication to the Jenkins through GitHub.
 
-    Go to the [Register a new OAuth application] and use the following settings to setup your app.
+	Go to the [Register a new OAuth application] and use the following settings to setup your app.
 
-    The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
+	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
 
-      * Application name:  `jenkins-[environment]-[team-name]` , e.g. `jenkins-dev-my-team`.
+	* Application name:  jenkins-[environment]-[team-name]  e.g. jenkins-dev-my-team
+	* Homepage URL:  [URL]
+	* Application description:  Build system for [URL]
+	* Authorization callback URL:  [URL]/securityRealm/finishLogin
 
-      * Homepage URL:  `[URL]`
+	Then, click the 'Register application' button.
 
-      * Application description:  `Build system for [URL]`
+	Export the credentials as they appear on the screen:
 
-      * Authorization callback URL:  `[URL]/securityRealm/finishLogin`
+	If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
 
-    Then, click the 'Register application' button.
-
-    Export the credentials as they appear on the screen:
-
-    If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
-
-    ```
-    export JENKINS_GITHUB_OAUTH_ID="[client-id]"
-    export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
-    ```
+	```
+	export JENKINS_GITHUB_OAUTH_ID="[client-id]"
+	export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
+	```
 
 1. Set Jenkins related environment variables
 
-    ```
-    export JENKINS_TEAM_NAME="my-team"
-    export JENKINS_ENV_NAME="dev"
-    ```
+	```
+	export JENKINS_TEAM_NAME="my-team"
+	export JENKINS_ENV_NAME="dev"
+	```
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
-    ```
-    ./create-s3-state-bucket \
-      -t $JENKINS_TEAM_NAME \
-      -e $JENKINS_ENV_NAME \
-      -p [my-aws-profile]
-    ```
+	```
+	./create-s3-state-bucket \
+	  -t $JENKINS_TEAM_NAME \
+	  -e $JENKINS_ENV_NAME \
+	  -p [my-aws-profile]
+	```
 
 1. Change back into the `examples/complete_deployment_of_dns_and_jenkins` directory
 
 1. Initialise Terraform
 
-    ```
-    terraform init \
-      -backend-config="region=$AWS_DEFAULT_REGION" \
-      -backend-config="key=re-build-systems.tfstate" \
-      -backend-config="bucket=tfstate-$JENKINS_TEAM_NAME-$JENKINS_ENV_NAME"
-    ```
+	```
+	terraform init \
+	  -backend-config="region=$AWS_DEFAULT_REGION" \
+	  -backend-config="key=re-build-systems.tfstate" \
+	  -backend-config="bucket=tfstate-$JENKINS_TEAM_NAME-$JENKINS_ENV_NAME"
+	```
 
 1. Plan and Apply Terraform
 
-    ```
-    terraform plan \
-      -var-file=./terraform.tfvars  \
-      -var environment=$JENKINS_ENV_NAME \
-      -var github_client_id=$JENKINS_GITHUB_OAUTH_ID \
-      -var github_client_secret=$JENKINS_GITHUB_OAUTH_SECRET \
-      -out my-plan.txt
-    ```
+	```
+	terraform plan \
+	  -var-file=./terraform.tfvars  \
+	  -var environment=$JENKINS_ENV_NAME \
+	  -var github_client_id=$JENKINS_GITHUB_OAUTH_ID \
+	  -var github_client_secret=$JENKINS_GITHUB_OAUTH_SECRET \
+	  -out my-plan.txt
+	```
 
-    ```
-    terraform apply \
-      -var-file=./terraform.tfvars  \
-      -var environment=$JENKINS_ENV_NAME \
-      -var github_client_id=$JENKINS_GITHUB_OAUTH_ID \
-      -var github_client_secret=$JENKINS_GITHUB_OAUTH_SECRET \
-      my-plan.txt
-    ```
+	```
+	terraform apply \
+	  -var-file=./terraform.tfvars  \
+	  -var environment=$JENKINS_ENV_NAME \
+	  -var github_client_id=$JENKINS_GITHUB_OAUTH_ID \
+	  -var github_client_secret=$JENKINS_GITHUB_OAUTH_SECRET \
+	  my-plan.txt
+	```
 
 ## Contributing
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -77,12 +77,12 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Edit the `terraform.tfvars` file to reflect the following configuration:
 
-  | Name | Var Type | Required | Default | Description |
-  | :--- | :--- | :--: | :--- | :--- |
-  | `aws_profile` | string | | The default AWS profile in `~/.aws/credentials` | AWS Profile (credentials) to use |
-  | `aws_region` | string | | default AWS region | The AWS Region to be used, eg. `eu-west-1` |
-  | `hostname_suffix` | string | **yes** | none | Main domain name for new Jenkins instances, for GDS use `build.gds-reliability.engineering` |
-  | `team_name` | string | **yes** | none | Name of your team. This is used to construct the DNS name for your Jenkins instances |
+	| Name | Var Type | Required | Default | Description |
+	| :--- | :--- | :--: | :--- | :--- |
+	| `aws_profile` | string | | The default AWS profile in `~/.aws/credentials` | AWS Profile (credentials) to use |
+	| `aws_region` | string | | default AWS region | The AWS Region to be used, eg. `eu-west-1` |
+	| `hostname_suffix` | string | **yes** | none | Main domain name for new Jenkins instances, for GDS use `build.gds-reliability.engineering` |
+	| `team_name` | string | **yes** | none | Name of your team. This is used to construct the DNS name for your Jenkins instances |
 
 1. Initialise Terraform
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -239,11 +239,11 @@ Refer to our [Contributing guide].
 
 [MIT License]
 
-[architectural documentation]: docs/architecture/README.md
+[architectural documentation]: https://github.com/alphagov/re-build-systems/tree/master/docs/architecture
 [AWS Command Line Interface (CLI)]: https://aws.amazon.com/cli/
-[Contributing guide]: CONTRIBUTING.md
+[Contributing guide]: https://github.com/alphagov/re-build-systems/blob/master/CONTRIBUTING.md
 [Jenkins (version 2)]: https://jenkins.io/2.0/
-[MIT License]: LICENSE
+[MIT License]: https://github.com/alphagov/re-build-systems/blob/master/LICENCE
 [Register a new OAuth application]: https://github.com/settings/applications/new
 [S3 bucket]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
 [Terraform]: https://www.terraform.io/intro/index.html

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -70,17 +70,17 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Clone the re-build-systems repo
 
-  ```
-  git clone https://github.com/alphagov/re-build-systems.git
-  ```
+	```
+	git clone https://github.com/alphagov/re-build-systems.git
+	```
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
 	```
 	./create-dns-s3-state-bucket \
-		-d build.gds-reliability.engineering \
-		-p [my-aws-profile] \
-		-t $JENKINS_TEAM_NAME
+	  -d build.gds-reliability.engineering \
+	  -p [my-aws-profile] \
+	  -t $JENKINS_TEAM_NAME
 	```
 
 1. Change into the `examples/gds_specific_dns_and_jenkins/dns` directory
@@ -100,9 +100,9 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 	```
 	terraform init \
-		-backend-config="region=$AWS_DEFAULT_REGION" \
-		-backend-config="bucket=tfstate-dns-$JENKINS_TEAM_NAME.build.gds-reliability.engineering" \
-		-backend-config="key=$JENKINS_TEAM_NAME.build.gds-reliability.engineering.tfstate"
+	  -backend-config="region=$AWS_DEFAULT_REGION" \
+	  -backend-config="bucket=tfstate-dns-$JENKINS_TEAM_NAME.build.gds-reliability.engineering" \
+	  -backend-config="key=$JENKINS_TEAM_NAME.build.gds-reliability.engineering.tfstate"
 	```
 
 1. Run this command to apply the Terraform using your custom configuration
@@ -118,10 +118,10 @@ Start by provisioning the DNS for one environment, add other environments later.
 	team_domain_name = [team_name].build.gds-reliability.engineering
 	team_zone_id = A1AAAA11AAA11A
 	team_zone_nameservers = [
-		ns-1234.awsdns-56.org,
-		ns-7890.awsdns-12.co.uk,
-		ns-345.awsdns-67.com,
-		ns-890.awsdns-12.net
+	  ns-1234.awsdns-56.org,
+	  ns-7890.awsdns-12.co.uk,
+	  ns-345.awsdns-67.com,
+	  ns-890.awsdns-12.net
 	]
 	```
 
@@ -139,28 +139,25 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 1. Create a GitHub OAuth app to allow you to setup authentication to the Jenkins through GitHub.
 
-    Go to the [Register a new OAuth application] and use the following settings to setup your app.
+	Go to the [Register a new OAuth application] and use the following settings to setup your app.
 
-    The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
+	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
 
-      * Application name:  `jenkins-[environment]-[team-name]` , e.g. `jenkins-dev-my-team`.
+		* Application name:  jenkins-[environment]-[team-name] e.g. jenkins-dev-my-team
+		* Homepage URL:  [URL]
+		* Application description:  Build system for [URL]
+		* Authorization callback URL:  [URL]/securityRealm/finishLogin
 
-      * Homepage URL:  `[URL]`
+	Then, click the 'Register application' button.
 
-      * Application description:  `Build system for [URL]`
+	Export the credentials as they appear on the screen:
 
-      * Authorization callback URL:  `[URL]/securityRealm/finishLogin`
+	If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
 
-    Then, click the 'Register application' button.
-
-    Export the credentials as they appear on the screen:
-
-    If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
-
-    ```
-    export JENKINS_GITHUB_OAUTH_ID="[client-id]"
-    export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
-    ```
+	```
+	export JENKINS_GITHUB_OAUTH_ID="[client-id]"
+	export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
+	```
 
 1. Export the environment and team names set during DNS provisioning
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -159,6 +159,11 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 	export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
 	```
 
+1. Transfer ownership of the Github OAuth app
+	Skip this step if you are provisioning the platform only for test or development purpose. Otherwise, you should transfer ownership of the app to `alphagov` so that it can be managed by GDS.
+
+	To do so, click the "Transfer ownership" button located at the top of the page where you copied the credentials from. Input `alphagov` as organisation.
+
 1. Export the environment and team names set during DNS provisioning
 
 	```

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -1,5 +1,7 @@
 # Example configuration for GDS teams
 
+This working example specific to GDS users demonstrates how you can use our modules to deploy jenkins using terraform.  By working through the example it will result in you having a working deployment of jenkins using our terraform modules.
+
 There are 3 initial steps to set up your Jenkins platform:
 
 1. Provision the DNS infrastructure.

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -47,6 +47,7 @@ Start by provisioning the DNS for one environment, add other environments later.
 	```
 
 1. Set AWS environment variables
+
 	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 	```
@@ -72,7 +73,7 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Change into the `examples/gds_specific_dns_and_jenkins/dns` directory
 
-1. Rename the `terraform.tfvars.example` file as `terraform.tfvars`.
+1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 1. Edit the `terraform.tfvars` file to reflect the following configuration:
 
@@ -142,12 +143,12 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
     Export the credentials as they appear on the screen:
 
+    If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
+
     ```
     export JENKINS_GITHUB_OAUTH_ID="[client-id]"
     export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
     ```
-
-    If you're using bash, add a space at the start of export `AWS_ACCESS_KEY_ID` and export `AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 1. Export the environment and team names set during DNS provisioning
 
@@ -158,13 +159,13 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 1. Set AWS environment variables
 
+	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to ~/.bash_history.
+
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"
 	export AWS_SECRET_ACCESS_KEY="[aws secret]"
 	export AWS_DEFAULT_REGION="[aws region]"
 	```
-
-    If you're using bash, add a space at the start of export AWS_ACCESS_KEY_ID and export AWS_SECRET_ACCESS_KEY to prevent them from being added to ~/.bash_history.
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
@@ -177,7 +178,7 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 1. Change into the `examples/gds_specific_dns_and_jenkins/jenkins` directory
 
-1. Rename the `terraform.tfvars.example` file as `terraform.tfvars`.
+1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 1. Edit the `terraform.tfvars` file to reflect the following configuration:
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -143,10 +143,12 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 	The [URL] will follow the pattern `https://[environment].[team_name].[hostname_suffix]`.  For example `https://dev.my-team.build.gds-reliability.engineering`
 
-		* Application name:  jenkins-[environment]-[team-name] e.g. jenkins-dev-my-team
-		* Homepage URL:  [URL]
-		* Application description:  Build system for [URL]
-		* Authorization callback URL:  [URL]/securityRealm/finishLogin
+	```
+	Application name: jenkins-[environment]-[team-name] e.g. jenkins-dev-my-team
+	Homepage URL: [URL]
+	Application description: Build system for [URL]
+	Authorization callback URL: [URL]/securityRealm/finishLogin
+	```
 
 	Then, click the 'Register application' button.
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -2,6 +2,8 @@
 
 This working example specific to GDS users demonstrates how you can use our modules to deploy jenkins using terraform.  By working through the example it will result in you having a working deployment of jenkins using our terraform modules.
 
+To work through this example you will need to clone this repo.
+
 There are 3 initial steps to set up your Jenkins platform:
 
 1. Provision the DNS infrastructure.
@@ -63,6 +65,12 @@ Start by provisioning the DNS for one environment, add other environments later.
 	```
 	export JENKINS_TEAM_NAME="[my-team-name]"
 	```
+
+1. Clone the re-build-systems repo
+
+  ```
+  git clone https://github.com/alphagov/re-build-systems.git
+  ```
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -247,6 +247,11 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 	terraform apply "terraform.plan"
 	```
 
+## Next Steps
+
+	* The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to gain control
+	* ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
+
 ## Contributing
 
 Refer to our [Contributing guide].

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -40,36 +40,35 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Add your AWS user credentials to `~/.aws/credentials`. If this file does not exist, you'll need to create it.
 
-    ```
-    [re-build-systems]
-    aws_access_key_id = [your aws key here]
-    aws_secret_access_key = [your aws secret here]
-    ```
+	```
+	[re-build-systems]
+	aws_access_key_id = [your aws key here]
+	aws_secret_access_key = [your aws secret here]
+	```
 
 1. Set AWS environment variables
+	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
-  If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
-
-    ```
-    export AWS_ACCESS_KEY_ID="[aws key]"
-    export AWS_SECRET_ACCESS_KEY="[aws secret]"
-    export AWS_DEFAULT_REGION="[aws region]"
-    ```
+	```
+	export AWS_ACCESS_KEY_ID="[aws key]"
+	export AWS_SECRET_ACCESS_KEY="[aws secret]"
+	export AWS_DEFAULT_REGION="[aws region]"
+	```
 
 1. Set Jenkins related environment variables
 
-  ```
-  export JENKINS_TEAM_NAME="[my-team-name]"
-  ```
+	```
+	export JENKINS_TEAM_NAME="[my-team-name]"
+	```
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
-  ```
-  create-dns-s3-state-bucket \
-    -d build.gds-reliability.engineering \
-    -p [my-aws-profile] \
-    -t $JENKINS_TEAM_NAME
-  ```
+	```
+	create-dns-s3-state-bucket \
+		-d build.gds-reliability.engineering \
+		-p [my-aws-profile] \
+		-t $JENKINS_TEAM_NAME
+	```
 
 1. Change into the `examples/gds_specific_dns_and_jenkins/dns` directory
 
@@ -86,12 +85,12 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Initialise Terraform
 
-  ```
-  terraform init \
-    -backend-config="region=$AWS_DEFAULT_REGION" \
-    -backend-config="bucket=tfstate-dns-$JENKINS_TEAM_NAME.build.gds-reliability.engineering" \
-    -backend-config="key=$JENKINS_TEAM_NAME.build.gds-reliability.engineering.tfstate"
-  ```
+	```
+	terraform init \
+		-backend-config="region=$AWS_DEFAULT_REGION" \
+		-backend-config="bucket=tfstate-dns-$JENKINS_TEAM_NAME.build.gds-reliability.engineering" \
+		-backend-config="key=$JENKINS_TEAM_NAME.build.gds-reliability.engineering.tfstate"
+	```
 
 1. Run this command to apply the Terraform using your custom configuration
 
@@ -101,23 +100,23 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. You will get an output in your terminal that looks like this:
 
-    ```
-    Outputs:
-    team_domain_name = [team_name].build.gds-reliability.engineering
-    team_zone_id = A1AAAA11AAA11A
-    team_zone_nameservers = [
-      ns-1234.awsdns-56.org,
-      ns-7890.awsdns-12.co.uk,
-      ns-345.awsdns-67.com,
-      ns-890.awsdns-12.net
-    ]
-    ```
+	```
+	Outputs:
+	team_domain_name = [team_name].build.gds-reliability.engineering
+	team_zone_id = A1AAAA11AAA11A
+	team_zone_nameservers = [
+		ns-1234.awsdns-56.org,
+		ns-7890.awsdns-12.co.uk,
+		ns-345.awsdns-67.com,
+		ns-890.awsdns-12.net
+	]
+	```
 
-    If you receive an error, it may be because your `team_name` is not unique. Your `team_name` must be unique to ensure the associated URLs are unique. Go back to step 7, change your `team_name` and then continue from that point.
+	If you receive an error, it may be because your `team_name` is not unique. Your `team_name` must be unique to ensure the associated URLs are unique. Go back to step 7, change your `team_name` and then continue from that point.
 
-    Copy and send this output to the GDS Reliability Engineering team at reliability-engineering@digital.cabinet-office.gov.uk. The team will make your URL live.
+	Copy and send this output to the GDS Reliability Engineering team at reliability-engineering@digital.cabinet-office.gov.uk. The team will make your URL live.
 
-    This step may take up to two working days, if you progress to the next step before awaiting confirmation from the GDS Reliability Engineering team, your domain will not be configured and it will cause errors when generating the TLS certificate used for HTTPS.
+	This step may take up to two working days, if you progress to the next step before awaiting confirmation from the GDS Reliability Engineering team, your domain will not be configured and it will cause errors when generating the TLS certificate used for HTTPS.
 
 ## Provision the main Jenkins infrastructure
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -251,8 +251,8 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 ## Next Steps
 
-	* The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to gain control
-	* ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
+* The jenkins master and agent server have unrestricted outwards access to the internet, we suggest implementing an egress proxy, security groups etc to restrict access
+* ssh access is available by `ssh -i /path/to/private.key ubuntu@[url]`
 
 ## Contributing
 

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -52,12 +52,14 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 1. Set AWS environment variables
 
+	**Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
+
 	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"
 	export AWS_SECRET_ACCESS_KEY="[aws secret]"
-	export AWS_DEFAULT_REGION="[aws region]"
+	export AWS_DEFAULT_REGION="eu-west-1"
 	```
 
 1. Set Jenkins related environment variables
@@ -174,7 +176,7 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"
 	export AWS_SECRET_ACCESS_KEY="[aws secret]"
-	export AWS_DEFAULT_REGION="[aws region]"
+	export AWS_DEFAULT_REGION="eu-west-1"
 	```
 
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -54,7 +54,7 @@ Start by provisioning the DNS for one environment, add other environments later.
 
 	**Note:** Our modules use AWS EFS for persistent storage and currently EFS is not available in the London region (eu-west-2), in this example we will use Ireland (eu-west-1).
 
-	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
+	**Note:** If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to `~/.bash_history`.
 
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"
@@ -152,12 +152,14 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 	Export the credentials as they appear on the screen:
 
-	If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
+	**Note:** If you're using bash, add a space at the start of `export JENKINS_GITHUB_OAUTH_ID` and `export JENKINS_GITHUB_OAUTH_SECRET` to prevent them from being added to `~/.bash_history`.
 
 	```
 	export JENKINS_GITHUB_OAUTH_ID="[client-id]"
 	export JENKINS_GITHUB_OAUTH_SECRET="[client-secret]"
 	```
+
+	The github credentials are exported so that no secrets are stored on the local machine.
 
 1. Transfer ownership of the Github OAuth app
 	Skip this step if you are provisioning the platform only for test or development purpose. Otherwise, you should transfer ownership of the app to `alphagov` so that it can be managed by GDS.
@@ -173,7 +175,7 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 
 1. Set AWS environment variables
 
-	If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to ~/.bash_history.
+	**Note:** If you're using bash, add a space at the start of `export AWS_ACCESS_KEY_ID` and `export AWS_SECRET_ACCESS_KEY` to prevent them from being added to ~/.bash_history.
 
 	```
 	export AWS_ACCESS_KEY_ID="[aws key]"

--- a/examples/gds_specific_dns_and_jenkins/README.md
+++ b/examples/gds_specific_dns_and_jenkins/README.md
@@ -64,7 +64,7 @@ Start by provisioning the DNS for one environment, add other environments later.
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
 	```
-	create-dns-s3-state-bucket \
+	./create-dns-s3-state-bucket \
 		-d build.gds-reliability.engineering \
 		-p [my-aws-profile] \
 		-t $JENKINS_TEAM_NAME
@@ -169,7 +169,7 @@ You'll need to choose which environment you want to set up Jenkins for, for exam
 1. Create the [S3 bucket] to host the Terraform state file by running this command from the `tools` directory:
 
 	```
-	create-s3-state-bucket \
+	./create-s3-state-bucket \
 	  -t $JENKINS_TEAM_NAME \
 	  -e $JENKINS_ENV_NAME \
 	  -p [my-aws-profile]


### PR DESCRIPTION
- fix broken relative links
- fix numbering issue
- fix table indentation issue
- add step to clone repo
- add guidance on how to use the repo
- prepend ./ to script
- explain why using eu-west-1 rather than eu-west-2
- explain for gds specific example to transfer github auth app ownership to alphagov
- re-arrange ordering of instructions concerning ` ` in from of export commands which expose secrets
- explain why exporting secrets
- convert all documentation to use tabs rather than space (which was inconsistently applied which caused the whitespace and numbering issues)
- added next steps, with recommedations and pointed out the examples give unrestricted outbound internet access

Solo: @smford 